### PR TITLE
feat(gametree-plan): 对齐 v4 骨架与沙盒计划

### DIFF
--- a/docs/architecture/STORY_PIPELINE_V4.md
+++ b/docs/architecture/STORY_PIPELINE_V4.md
@@ -19,6 +19,9 @@ v4 版本的目标：在保持现有 v3 成熟组件的前提下，引入**骨�
 - **v4 主路径（默认）**：  
   文档 → Skeleton Generator（PlotSkeleton）→ TreeBuilder（guided）→ 文本填充（NodeTextFiller）→ 校验（story_report）
 
+- **v4 沙盒对齐方向（GameTree v1）**：
+  文档 → Skeleton Generator（PlotSkeleton 内容大纲）→ GameTreePlan（沙盒拓扑计划）→ 后续 GameTree v1 导出 / 审计
+
 - **v3 兼容路径**：  
   文档 → `DialogueTreeBuilder`（结构+文案一起生成）→ 校验 → 同轮扩展 / env 降级（legacy heuristics）
 
@@ -59,9 +62,30 @@ v4 版本的目标：在保持现有 v3 成熟组件的前提下，引入**骨�
     - 默认 `USE_PLOT_SKELETON=1`：必须先尝试骨架生成，进入 v4 骨架模式；
     - `USE_PLOT_SKELETON=0`：跳过本阶段，直接走 v3 兼容路径。
 
+### Stage B2：GameTreePlan（沙盒拓扑计划，v7 对齐层）
+
+**新组件**：`pregenerator/gametree_plan.py`
+
+- 输入：
+  - `PlotSkeleton`
+- 输出：
+  - `GameTreePlan`
+- 职责边界：
+  - `PlotSkeleton` 只记录内容大纲：幕、节拍、张力、分支、`location_id`、`npc_ids`、`event_slots`、`asset_cues`、`sandbox_role`、`revisit_hooks`;
+  - `GameTreePlan` 负责计划沙盒拓扑：地标、地标连接、工具节点、NPC 路线、beat 到未来节点的映射、演出兜底和验收目标;
+  - `GameTreePlan.to_minimal_tree()` 只作为 M3 内存验证和后续生成器对齐用的草案导出,不是最终正式剧本。
+- 设计约束：
+  - 不修改 DB schema;
+  - 不替换 `hangzhou_yebanbaoan/tree.json`;
+  - 不在 M3 阶段把 `audit_playability.py` 正式接进生成流水线;
+  - M4 再决定 `audit_sandbox.py` / `audit_playability.py` 的生成链路守门方式。
+
 ### Stage C：骨架驱动的 TreeBuilder（v4 guided）
 
 **改造组件**：`DialogueTreeBuilder`
+
+> 兼容说明：Stage C 是当前 v4 默认生成链路的运行路径。
+> 对齐 ADR-010 后，`PlotSkeleton` 的职责收敛为内容大纲；沙盒地图、工具节点、NPC 出没和演出槽位应先进入 `GameTreePlan`，再进入后续 GameTree v1 导出。不要把这些拓扑细节塞回 `DialogueTreeBuilder` 的启发式里。
 
 - 新增参数：
 
@@ -107,7 +131,7 @@ def __init__(..., plot_skeleton: Optional[Dict[str, Any]] = None, ...):
   - 对 narrative 为空或全空白的节点填充占位叙事，不覆盖已有文案。
 - `build_story_report(tree, skeleton)`：
   - 利用 `TimeValidator` + 骨架指标生成结构+时长+结局综合报告；
-  - 至少打印主角 `depth_ok / duration_ok / endings_ok` 摘要，作为人工验收入口。
+- 至少打印主角 `depth_ok / duration_ok / endings_ok` 摘要，作为人工验收入口。
 
 ---
 

--- a/docs/tasks/TASK_V4_GAMETREE_ALIGNMENT.md
+++ b/docs/tasks/TASK_V4_GAMETREE_ALIGNMENT.md
@@ -1,6 +1,6 @@
 # TASK: v4 生成器对齐 GameTree v1 沙盒拓扑
 
-版本: v0.1
+版本: v0.2
 状态: Active
 关联:
 - `docs/tasks/TASK_GAMETREE_V1.md`
@@ -32,9 +32,9 @@
 
 ### 目标
 
-- [ ] 扩展 `PlotSkeleton` 数据模型,让 beat 能表达沙盒所需的最小定位信息;
-- [ ] 更新 `plot-skeleton.prompt.md`,要求 LLM 输出地标、NPC、工具节点和演出提示;
-- [ ] 增加一个 `GameTreePlan` 或等价中间层,把骨架大纲转成 `GameTree v1` 形状前的结构计划;
+- [x] 扩展 `PlotSkeleton` 数据模型,让 beat 能表达沙盒所需的最小定位信息;
+- [x] 更新 `plot-skeleton.prompt.md`,要求 LLM 输出地标、NPC、工具节点和演出提示;
+- [x] 增加一个 `GameTreePlan` 或等价中间层,把骨架大纲转成 `GameTree v1` 形状前的结构计划;
 - [ ] 让生成链路产物能被 `audit_playability.py` 和后续 `audit_sandbox.py` 检查;
 - [ ] 保持 v3 legacy / 当前手写 v7 正式树兼容。
 
@@ -82,21 +82,21 @@
 
 ### M1: 模型与兼容
 
-- [ ] 扩展 `skeleton_model.py`;
-- [ ] 更新 `tests/test_skeleton_model.py`,确保 `to_dict/from_dict` 往返不丢字段;
-- [ ] 老 skeleton JSON 缺字段时仍能加载。
+- [x] 扩展 `skeleton_model.py`;
+- [x] 更新 `tests/test_skeleton_model.py`,确保 `to_dict/from_dict` 往返不丢字段;
+- [x] 老 skeleton JSON 缺字段时仍能加载。
 
 ### M2: Prompt 与生成
 
-- [ ] 更新 `templates/plot-skeleton.prompt.md`;
-- [ ] 更新 `skeleton_generator.py` 的解析 / 校验;
-- [ ] 为新字段加最小单测。
+- [x] 更新 `templates/plot-skeleton.prompt.md`;
+- [x] 更新 `skeleton_generator.py` 的解析 / 校验;
+- [x] 为新字段加最小单测。
 
 ### M3: GameTreePlan 草案
 
-- [ ] 新增 `pregenerator/gametree_plan.py`;
-- [ ] 从 `PlotSkeleton` 生成最小 `GameTreePlan`;
-- [ ] 为 hub / landmark / tool / ending_gate 建最小结构测试。
+- [x] 新增 `pregenerator/gametree_plan.py`;
+- [x] 从 `PlotSkeleton` 生成最小 `GameTreePlan`;
+- [x] 为 hub / landmark / tool / ending_gate 建最小结构测试。
 
 ### M4: 审计接入
 
@@ -113,3 +113,16 @@
 - v4 生成链路能明确产出“沙盒计划”,而不是只产出线性 act/beat;
 - 文档明确 `PlotSkeleton` 和 `GameTreePlan` 的职责边界;
 - 不影响正式 `hangzhou_yebanbaoan/tree.json` 的运行与审计结果。
+
+---
+
+## 5. 进展记录
+
+### 2026-05-09: M1-M3 第一批落地
+
+- `BeatConfig` 增加 `location_id / npc_ids / event_slots / asset_cues / sandbox_role / revisit_hooks`,全部为可选字段;
+- `PlotSkeleton.from_dict()` 继续兼容旧 JSON,缺少新字段时默认给空值;
+- `plot-skeleton.prompt.md` 已要求 LLM 输出地标、NPC、工具节点、演出提示和重访钩子;
+- 新增 `pregenerator/gametree_plan.py`,把内容骨架转换成计划层的 `locations / tools / npc_routes / beats / presentation_defaults / acceptance`;
+- `GameTreePlan.to_minimal_tree()` 只用于内存测试和后续生成器对齐,不写正式树、不改 DB schema、不接入正式审计链;
+- M4 仍保留为后续工作:新增或接入 `audit_sandbox.py`,并决定何时挂入 `tools/run_all_tests.py`。

--- a/src/ghost_story_factory/pregenerator/gametree_plan.py
+++ b/src/ghost_story_factory/pregenerator/gametree_plan.py
@@ -1,0 +1,331 @@
+"""GameTreePlan 中间层。
+
+`PlotSkeleton` 只负责内容大纲;`GameTreePlan` 负责把大纲收敛成
+GameTree v1 之前的沙盒拓扑计划。这里不生成最终节点文案,也不碰 DB schema。
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .skeleton_model import BeatConfig, PlotSkeleton
+
+
+@dataclass
+class LocationPlan:
+    """一个可探索地标。"""
+
+    id: str
+    label: str
+    beat_ids: List[str] = field(default_factory=list)
+    connections: List[str] = field(default_factory=list)
+    npc_ids: List[str] = field(default_factory=list)
+    event_slots: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ToolPlan:
+    """可反复访问的工具节点计划。"""
+
+    id: str
+    location_id: str
+    beat_id: str
+    revisit_hooks: List[str] = field(default_factory=list)
+    asset_cues: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class NpcRoutePlan:
+    """NPC 在沙盒地图中的最小出没计划。"""
+
+    npc_id: str
+    location_ids: List[str] = field(default_factory=list)
+    beat_ids: List[str] = field(default_factory=list)
+
+
+@dataclass
+class BeatNodePlan:
+    """beat 到未来 GameTree 节点的候选映射。"""
+
+    beat_id: str
+    node_id: str
+    location_id: str
+    sandbox_role: str = "landmark"
+    event_slots: List[str] = field(default_factory=list)
+    asset_cues: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AcceptancePlan:
+    """ADR-010 最小沙盒骨架的计划级验收目标。"""
+
+    min_locations: int = 4
+    min_tools: int = 2
+    requires_picker_hub: bool = True
+    requires_stay_loop: bool = True
+    requires_reaction_variant: bool = True
+
+
+@dataclass
+class GameTreePlan:
+    """从 PlotSkeleton 派生的 GameTree v1 拓扑计划。"""
+
+    title: str
+    picker_location_id: str = ""
+    story_id: str = "generated"
+    start_node: str = "n_intro"
+    locations: List[LocationPlan] = field(default_factory=list)
+    tools: List[ToolPlan] = field(default_factory=list)
+    npc_routes: List[NpcRoutePlan] = field(default_factory=list)
+    beats: List[BeatNodePlan] = field(default_factory=list)
+    presentation_defaults: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    acceptance: AcceptancePlan = field(default_factory=AcceptancePlan)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """转成可 JSON 序列化的字典。"""
+        return asdict(self)
+
+    @classmethod
+    def from_skeleton(cls, skeleton: PlotSkeleton) -> "GameTreePlan":
+        """从 PlotSkeleton 构建计划。"""
+        return build_gametree_plan(skeleton)
+
+    def to_minimal_tree(self) -> Dict[str, Any]:
+        """导出一棵最小 GameTree v1 形状的内存树。
+
+        这个导出只服务 M3 单元测试和后续生成器对齐,不是最终剧本。
+        """
+        picker_node_id = "n_map_picker"
+        backgrounds = {"text_fallback": {"text_fallback": "文本演出兜底"}}
+        nodes: Dict[str, Dict[str, Any]] = {
+            self.start_node: {
+                "node_id": self.start_node,
+                "narrative": f"{self.title} 的入口。",
+                "choices": [{"text": "进入地图", "next": picker_node_id}],
+                "presentation": {"background": "text_fallback"},
+            },
+            picker_node_id: {
+                "node_id": picker_node_id,
+                "_is_map_picker": True,
+                "narrative": "选择要调查的地标。",
+                "choices": [],
+                "presentation": {"background": "text_fallback"},
+            },
+        }
+
+        landmark_map: List[Dict[str, Any]] = []
+        tool_by_location: Dict[str, List[ToolPlan]] = {}
+        for tool in self.tools:
+            tool_by_location.setdefault(tool.location_id, []).append(tool)
+
+        for location in self.locations:
+            node_id = f"n_loc_{_slug(location.id)}"
+            landmark_map.append(
+                {
+                    "id": location.id,
+                    "label": location.label,
+                    "node_id": node_id,
+                    "connections": list(location.connections),
+                }
+            )
+            choices: List[Dict[str, Any]] = []
+            for tool in tool_by_location.get(location.id, []):
+                choices.append({"text": f"检查 {tool.id}", "next": f"n_{_slug(tool.id)}"})
+            if not choices:
+                choices.append({"text": "回到地图", "next": picker_node_id})
+            presentation = self.presentation_defaults.get(
+                location.id,
+                {"background": "text_fallback"},
+            )
+            _register_background(backgrounds, presentation)
+            nodes[node_id] = {
+                "node_id": node_id,
+                "narrative": f"你抵达 {location.label}。",
+                "choices": choices,
+                "presentation": presentation,
+            }
+
+        for index, tool in enumerate(self.tools):
+            node_id = f"n_{_slug(tool.id)}"
+            presentation = tool.asset_cues or {"background": "text_fallback"}
+            _register_background(backgrounds, presentation)
+            node: Dict[str, Any] = {
+                "node_id": node_id,
+                "_is_tool": True,
+                "narrative": f"你反复检查 {tool.id}。",
+                "choices": [
+                    {
+                        "text": "继续检查",
+                        "next": node_id,
+                        "effects": {"stay": True},
+                    }
+                ],
+                "presentation": presentation,
+            }
+            if index == 0:
+                node["narrative_variants"] = [
+                    {
+                        "if": {"deduction_resolved": "sandbox_probe"},
+                        "text": "你已经知道它真正指向哪里。",
+                    }
+                ]
+            nodes[node_id] = node
+
+        return {
+            "story_id": self.story_id,
+            "title": self.title,
+            "start_node": self.start_node,
+            "nodes": nodes,
+            "landmark_map": landmark_map,
+            "tools": {
+                tool.id: {
+                    "node_id": f"n_{_slug(tool.id)}",
+                    "location_id": tool.location_id,
+                    "revisit_hooks": list(tool.revisit_hooks),
+                }
+                for tool in self.tools
+            },
+            "endings": {},
+            "assets": {
+                "backgrounds": backgrounds,
+            },
+            "reaction_contracts": {
+                "deductions": {
+                    "sandbox_probe": {"label": "沙盒探针"}
+                },
+                "foreshadows": {},
+                "themes": {},
+            },
+        }
+
+
+def build_gametree_plan(skeleton: PlotSkeleton) -> GameTreePlan:
+    """从 PlotSkeleton 生成最小 GameTreePlan。
+
+    这是结构计划,不是最终可玩树。它只做几件硬事:
+    - 按 `location_id` 聚合 beat;
+    - 按出现顺序给地标补双向连接;
+    - 把 `tool` beat 抽成可回访工具计划;
+    - 把 NPC 出没压成 route;
+    - 为后续 presentation 兜底整理 asset cues。
+    """
+    location_map: Dict[str, LocationPlan] = {}
+    npc_map: Dict[str, NpcRoutePlan] = {}
+    beat_plans: List[BeatNodePlan] = []
+    tools: List[ToolPlan] = []
+    presentation_defaults: Dict[str, Dict[str, Any]] = {}
+    picker_location_id: Optional[str] = None
+
+    for beat in skeleton.beats:
+        location_id = _location_id_for(beat)
+        location = location_map.setdefault(
+            location_id,
+            LocationPlan(
+                id=location_id,
+                label=location_id,
+            ),
+        )
+        _append_unique(location.beat_ids, beat.id)
+        for npc_id in beat.npc_ids:
+            _append_unique(location.npc_ids, npc_id)
+        for slot in beat.event_slots:
+            _append_unique(location.event_slots, slot)
+
+        role = beat.sandbox_role or _role_from_slots(beat.event_slots)
+        if picker_location_id is None and (role == "hub" or "hub" in beat.event_slots):
+            picker_location_id = location_id
+
+        beat_plans.append(
+            BeatNodePlan(
+                beat_id=beat.id,
+                node_id=f"n_{_slug(beat.id)}",
+                location_id=location_id,
+                sandbox_role=role,
+                event_slots=list(beat.event_slots),
+                asset_cues=dict(beat.asset_cues),
+            )
+        )
+
+        if role == "tool" or "tool" in beat.event_slots:
+            tools.append(
+                ToolPlan(
+                    id=f"tool_{_slug(beat.id)}",
+                    location_id=location_id,
+                    beat_id=beat.id,
+                    revisit_hooks=list(beat.revisit_hooks),
+                    asset_cues=dict(beat.asset_cues),
+                )
+            )
+
+        for npc_id in beat.npc_ids:
+            route = npc_map.setdefault(npc_id, NpcRoutePlan(npc_id=npc_id))
+            _append_unique(route.location_ids, location_id)
+            _append_unique(route.beat_ids, beat.id)
+
+        if beat.asset_cues:
+            presentation_defaults[location_id] = {
+                **presentation_defaults.get(location_id, {}),
+                **beat.asset_cues,
+            }
+
+    locations = list(location_map.values())
+    _connect_locations(locations)
+    if picker_location_id is None and locations:
+        picker_location_id = locations[0].id
+
+    return GameTreePlan(
+        title=skeleton.title,
+        story_id=_slug(skeleton.title) or "generated",
+        start_node="n_intro",
+        picker_location_id=picker_location_id or "",
+        locations=locations,
+        tools=tools,
+        npc_routes=list(npc_map.values()),
+        beats=beat_plans,
+        presentation_defaults=presentation_defaults,
+    )
+
+
+def _location_id_for(beat: BeatConfig) -> str:
+    """缺少 location_id 时按 act 兜底,不让旧骨架崩。"""
+    if beat.location_id:
+        return beat.location_id
+    return f"act_{beat.act_index}"
+
+
+def _role_from_slots(event_slots: List[str]) -> str:
+    """从事件槽推导沙盒角色。"""
+    for role in ("hub", "tool", "ending", "payoff", "landmark"):
+        if role in event_slots:
+            return role
+    if "ending_gate" in event_slots:
+        return "ending"
+    return "landmark"
+
+
+def _connect_locations(locations: List[LocationPlan]) -> None:
+    """按出现顺序补双向邻接,形成最小可走地图。"""
+    for idx, location in enumerate(locations):
+        if idx > 0:
+            _append_unique(location.connections, locations[idx - 1].id)
+        if idx + 1 < len(locations):
+            _append_unique(location.connections, locations[idx + 1].id)
+
+
+def _append_unique(items: List[str], value: str) -> None:
+    """保持顺序的去重追加。"""
+    if value and value not in items:
+        items.append(value)
+
+
+def _register_background(backgrounds: Dict[str, Dict[str, str]], presentation: Dict[str, Any]) -> None:
+    """把演出提示里的背景登记成文本兜底资产。"""
+    bg = presentation.get("background")
+    if isinstance(bg, str) and bg and bg not in backgrounds:
+        backgrounds[bg] = {"text_fallback": bg}
+
+
+def _slug(value: str) -> str:
+    """生成稳定 node/tool ID 片段。"""
+    return "".join(ch.lower() if ch.isalnum() else "_" for ch in value).strip("_") or "beat"

--- a/src/ghost_story_factory/pregenerator/skeleton_model.py
+++ b/src/ghost_story_factory/pregenerator/skeleton_model.py
@@ -15,6 +15,20 @@ BeatType = Literal["setup", "escalation", "twist", "climax", "aftermath"]
 BranchType = Literal["CRITICAL", "NORMAL", "MICRO"]
 
 
+def _string_list(value: Any) -> List[str]:
+    """把 LLM 可能返回的列表字段收敛成字符串列表。"""
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _dict_value(value: Any) -> Dict[str, Any]:
+    """只接受对象字段,避免把错误类型带进内部模型。"""
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
 @dataclass
 class BranchSpec:
     """分支规格（定义某个节拍下可用的分支类型与数量约束）"""
@@ -46,6 +60,14 @@ class BeatConfig:
     is_critical_branch_point: bool = False
     leads_to_ending: bool = False
     branches: List[BranchSpec] = field(default_factory=list)
+    # 以下字段只描述内容大纲到沙盒拓扑的最小定位信息。
+    # 它们全部可空,保证旧 PlotSkeleton JSON 仍可正常加载。
+    location_id: Optional[str] = None
+    npc_ids: List[str] = field(default_factory=list)
+    event_slots: List[str] = field(default_factory=list)
+    asset_cues: Dict[str, Any] = field(default_factory=dict)
+    sandbox_role: Optional[str] = None
+    revisit_hooks: List[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "BeatConfig":
@@ -63,6 +85,8 @@ class BeatConfig:
 
         branches_raw = data.get("branches") or []
         branches = [BranchSpec.from_dict(b) for b in branches_raw if isinstance(b, dict)]
+        location_id = str(data.get("location_id") or "").strip() or None
+        sandbox_role = str(data.get("sandbox_role") or "").strip() or None
 
         return cls(
             id=str(data.get("id") or ""),
@@ -72,6 +96,12 @@ class BeatConfig:
             is_critical_branch_point=bool(data.get("is_critical_branch_point", False)),
             leads_to_ending=bool(data.get("leads_to_ending", False)),
             branches=branches,
+            location_id=location_id,
+            npc_ids=_string_list(data.get("npc_ids")),
+            event_slots=_string_list(data.get("event_slots")),
+            asset_cues=_dict_value(data.get("asset_cues")),
+            sandbox_role=sandbox_role,
+            revisit_hooks=_string_list(data.get("revisit_hooks")),
         )
 
 

--- a/templates/plot-skeleton.prompt.md
+++ b/templates/plot-skeleton.prompt.md
@@ -46,6 +46,17 @@
           "tension_level": 3,
           "is_critical_branch_point": false,
           "leads_to_ending": false,
+          "location_id": "S1_security_room",
+          "npc_ids": ["g273"],
+          "event_slots": ["hub", "npc_meet"],
+          "asset_cues": {
+            "background": "security_room",
+            "sprite": "g273",
+            "sfx": ["radio_noise"],
+            "cg_unlock": null
+          },
+          "sandbox_role": "hub",
+          "revisit_hooks": ["ending_seen:E_TRUTH"],
           "branches": [
             {
               "branch_type": "NORMAL",
@@ -77,6 +88,12 @@
     - `tension_level`: 1-10，表示紧张度
     - `is_critical_branch_point`: 若为 true，表示这里会产生 CRITICAL 分支
     - `leads_to_ending`: 若为 true，表示此节拍可以落到结局
+    - `location_id`: 该节拍归属的地标 / 场景 ID，建议使用稳定短 ID（例如 `S1_security_room`）
+    - `npc_ids`: 该节拍主要出场 NPC ID 列表，可为空数组
+    - `event_slots`: 该节拍承担的事件槽，例如 `"hub" | "landmark" | "tool" | "npc_meet" | "revisit" | "ending_gate"`
+    - `asset_cues`: VN 演出提示对象，可包含 `background` / `sprite` / `sfx` / `cg_unlock`，没有则给空对象或 null 值
+    - `sandbox_role`: 该节拍在沙盒拓扑中的角色，例如 `"hub" | "landmark" | "tool" | "payoff" | "ending"`
+    - `revisit_hooks`: 重访时可切换叙述的状态钩子，例如 `"deduction_resolved:radio_signal"` / `"ending_seen:E_TRUTH"`
     - `branches`: 针对该节拍的分支规划
       - `branch_type`: `"CRITICAL" | "NORMAL" | "MICRO"`
       - `max_children`: 此类分支在对应节点上的最大子节点数
@@ -118,10 +135,18 @@
    - `leads_to_ending = true` 的节拍应集中在后 1/3 的深度区间；
    - 早期幕（Act I）一般不直接落结局，除非是极端失败分支。
 
+5. **沙盒定位**
+   - 不要把骨架写成 `entry -> s1 -> s2 -> ending` 的死剧本。
+   - 至少规划 4 个可重复识别的 `location_id`，后续会转换为 `GameTreePlan.locations`。
+   - 至少 1 个节拍标记为 `sandbox_role = "hub"` 或 `event_slots` 包含 `"hub"`。
+   - 至少 2 个节拍标记为 `sandbox_role = "tool"` 或 `event_slots` 包含 `"tool"`，并给出 `revisit_hooks`。
+   - NPC 不要只出场一次；重要 NPC 应在多个 location / beat 中重复出现，并通过 `revisit_hooks` 体现状态变化。
+   - `asset_cues` 只给演出提示，不要编造真实图片路径。
+
 ---
 
 ## 输出要求（非常重要）
 
 1. **严格只输出一个 JSON 顶层对象**，不要输出任何解释性文字。
 2. 允许在 JSON 外层包裹 ```json 代码块（推荐）；也可以直接输出 JSON。
-3. 不要在 JSON 中包含注释或多余字段，保持结构与上文示例兼容。
+3. 不要在 JSON 中包含注释；字段应使用本文定义的 PlotSkeleton 字段，保持旧结构兼容。

--- a/tests/test_gametree_plan.py
+++ b/tests/test_gametree_plan.py
@@ -1,0 +1,114 @@
+"""GameTreePlan 草案单元测试。"""
+
+from ghost_story_factory.pregenerator.gametree_plan import GameTreePlan
+from ghost_story_factory.pregenerator.skeleton_model import (
+    ActConfig,
+    BeatConfig,
+    BranchSpec,
+    PlotSkeleton,
+    SkeletonConfig,
+)
+from tools.audit_playability import analyze_playability
+
+
+def _sandbox_skeleton() -> PlotSkeleton:
+    branches = [BranchSpec(branch_type="NORMAL", max_children=2)]
+    beats = [
+        BeatConfig(
+            id="A1_B1",
+            act_index=1,
+            beat_type="setup",
+            location_id="S1_security_room",
+            npc_ids=["g273"],
+            event_slots=["hub", "npc_meet"],
+            asset_cues={"background": "security_room"},
+            sandbox_role="hub",
+            branches=branches,
+        ),
+        BeatConfig(
+            id="A1_B2",
+            act_index=1,
+            beat_type="setup",
+            location_id="S2_lobby",
+            npc_ids=["red_girl"],
+            event_slots=["landmark"],
+            asset_cues={"background": "lobby"},
+            sandbox_role="landmark",
+            branches=branches,
+        ),
+        BeatConfig(
+            id="A2_B1",
+            act_index=2,
+            beat_type="escalation",
+            location_id="S3_archive",
+            npc_ids=["archivist"],
+            event_slots=["tool", "revisit"],
+            asset_cues={"background": "archive", "sfx": ["paper_noise"]},
+            sandbox_role="tool",
+            revisit_hooks=["deduction_resolved:sandbox_probe"],
+            branches=branches,
+        ),
+        BeatConfig(
+            id="A2_B2",
+            act_index=2,
+            beat_type="twist",
+            location_id="S4_roof",
+            npc_ids=["g273"],
+            event_slots=["tool", "ending_gate"],
+            asset_cues={"background": "roof"},
+            sandbox_role="tool",
+            revisit_hooks=["ending_seen:E_TRUTH"],
+            branches=branches,
+        ),
+    ]
+
+    return PlotSkeleton(
+        title="沙盒测试",
+        acts=[
+            ActConfig(index=1, label="Act I", beats=beats[:2]),
+            ActConfig(index=2, label="Act II", beats=beats[2:]),
+            ActConfig(index=3, label="Act III", beats=[]),
+        ],
+        config=SkeletonConfig(
+            min_main_depth=4,
+            target_main_depth=8,
+            target_endings=1,
+            max_branches_per_node=3,
+        ),
+    )
+
+
+def test_gametree_plan_from_skeleton_builds_sandbox_outline():
+    """从骨架生成的计划应有 hub、地标、工具和 NPC 路线。"""
+    plan = GameTreePlan.from_skeleton(_sandbox_skeleton())
+
+    assert plan.picker_location_id == "S1_security_room"
+    assert len(plan.locations) == 4
+    assert len(plan.tools) == 2
+    assert len(plan.npc_routes) == 3
+    assert all(location.connections for location in plan.locations)
+    assert plan.tools[0].revisit_hooks == ["deduction_resolved:sandbox_probe"]
+    assert plan.presentation_defaults["S3_archive"]["background"] == "archive"
+
+
+def test_gametree_plan_minimal_tree_passes_playability_redlines():
+    """M3 只验证内存导出能过基本可玩红线,不接正式审计链。"""
+    plan = GameTreePlan.from_skeleton(_sandbox_skeleton())
+    tree = plan.to_minimal_tree()
+    report = analyze_playability(tree)
+
+    assert report.ok
+    assert report.dynamic_picker_nodes == 1
+    assert report.reachable_nodes == report.total_nodes
+    assert len(tree["landmark_map"]) == 4
+    assert len(tree["tools"]) == 2
+    assert any(
+        choice.get("effects", {}).get("stay")
+        for node in tree["nodes"].values()
+        for choice in node.get("choices", [])
+    )
+    assert any(
+        variant.get("if", {}).get("deduction_resolved") == "sandbox_probe"
+        for node in tree["nodes"].values()
+        for variant in node.get("narrative_variants", [])
+    )

--- a/tests/test_skeleton_generator.py
+++ b/tests/test_skeleton_generator.py
@@ -35,6 +35,16 @@ DUMMY_SKELETON_JSON = """
           "tension_level": 3,
           "is_critical_branch_point": false,
           "leads_to_ending": false,
+          "location_id": "S1_security_room",
+          "npc_ids": ["g273"],
+          "event_slots": ["hub", "npc_meet"],
+          "asset_cues": {
+            "background": "security_room",
+            "sprite": "g273",
+            "sfx": ["radio_noise"]
+          },
+          "sandbox_role": "hub",
+          "revisit_hooks": ["ending_seen:E_TRUTH"],
           "branches": [
             {
               "branch_type": "NORMAL",
@@ -192,6 +202,13 @@ def test_skeleton_generator_with_llm_client(monkeypatch):
     assert skeleton.num_beats >= skeleton.config.min_main_depth
     assert skeleton.num_ending_beats >= skeleton.config.target_endings
     assert skeleton.metadata.get("city") == "测试城"
+    beat = skeleton.beats[0]
+    assert beat.location_id == "S1_security_room"
+    assert beat.npc_ids == ["g273"]
+    assert beat.event_slots == ["hub", "npc_meet"]
+    assert beat.asset_cues["background"] == "security_room"
+    assert beat.sandbox_role == "hub"
+    assert beat.revisit_hooks == ["ending_seen:E_TRUTH"]
 
 
 def test_skeleton_generator_smoke(monkeypatch):

--- a/tests/test_skeleton_model.py
+++ b/tests/test_skeleton_model.py
@@ -89,6 +89,12 @@ def test_plot_skeleton_roundtrip_dict():
             is_critical_branch_point=False,
             leads_to_ending=False,
             branches=branches,
+            location_id="S1",
+            npc_ids=["g273", "red_girl"],
+            event_slots=["npc_meet", "tool"],
+            asset_cues={"background": "security_room", "sfx": ["radio_noise"]},
+            sandbox_role="tool",
+            revisit_hooks=["deduction_resolved:radio_signal"],
         )
     ]
 
@@ -112,4 +118,47 @@ def test_plot_skeleton_roundtrip_dict():
     assert restored.num_beats == original.num_beats
     assert restored.config.min_main_depth == original.config.min_main_depth
     assert restored.metadata.get("city") == "测试城"
+    beat = restored.beats[0]
+    assert beat.location_id == "S1"
+    assert beat.npc_ids == ["g273", "red_girl"]
+    assert beat.event_slots == ["npc_meet", "tool"]
+    assert beat.asset_cues == {"background": "security_room", "sfx": ["radio_noise"]}
+    assert beat.sandbox_role == "tool"
+    assert beat.revisit_hooks == ["deduction_resolved:radio_signal"]
 
+
+def test_plot_skeleton_loads_legacy_beat_without_sandbox_fields():
+    """旧骨架缺少沙盒字段时仍能加载,默认值为空。"""
+    data = {
+        "title": "Legacy Story",
+        "config": {
+            "min_main_depth": 5,
+            "target_main_depth": 8,
+            "target_endings": 1,
+            "max_branches_per_node": 2,
+        },
+        "acts": [
+            {
+                "index": 1,
+                "label": "Act I",
+                "beats": [
+                    {
+                        "id": "B1",
+                        "act_index": 1,
+                        "beat_type": "setup",
+                        "branches": [],
+                    }
+                ],
+            }
+        ],
+    }
+
+    skeleton = PlotSkeleton.from_dict(data)
+    beat = skeleton.beats[0]
+
+    assert beat.location_id is None
+    assert beat.npc_ids == []
+    assert beat.event_slots == []
+    assert beat.asset_cues == {}
+    assert beat.sandbox_role is None
+    assert beat.revisit_hooks == []

--- a/tools/run_all_tests.py
+++ b/tools/run_all_tests.py
@@ -106,6 +106,7 @@ def main():
             [
                 "tests/test_skeleton_model.py",
                 "tests/test_skeleton_generator.py",
+                "tests/test_gametree_plan.py",
                 "tests/test_tree_builder_guided.py",
                 "tests/test_text_filler.py",
                 "tests/test_story_report.py",


### PR DESCRIPTION
## 背景\n\nRefs #23。\n\n这次只落 Issue #23 的 M1-M3：先让 v4 骨架能表达沙盒所需的最小定位信息，再新增 GameTreePlan 中间层。M4 的 audit_sandbox / 生成链路正式审计接入留后续 PR。\n\n## 改动\n\n- 扩展 `BeatConfig`：新增 `location_id / npc_ids / event_slots / asset_cues / sandbox_role / revisit_hooks`，全部可选，旧 skeleton JSON 仍兼容。\n- 更新 `plot-skeleton.prompt.md`：要求 LLM 输出地标、NPC、工具节点、演出提示和重访钩子，避免继续生成线性死剧本骨架。\n- 新增 `pregenerator/gametree_plan.py`：从 `PlotSkeleton` 生成 `GameTreePlan`，包含 locations / tools / npc_routes / beats / presentation_defaults / acceptance。\n- 新增 `GameTreePlan.to_minimal_tree()` 内存导出，用于验证计划层能形成 GameTree v1 的基本形状。\n- 新增 `tests/test_gametree_plan.py`，并挂入 `tools/run_all_tests.py`。\n- 更新 `TASK_V4_GAMETREE_ALIGNMENT.md` 与 `STORY_PIPELINE_V4.md`，明确 PlotSkeleton 与 GameTreePlan 的职责边界。\n\n## 验证\n\n- `.venv/bin/python -m pytest tests/test_skeleton_model.py tests/test_skeleton_generator.py tests/test_gametree_plan.py -q`\n- `bash tools/audit_all.sh`\n- `.venv/bin/python tools/run_all_tests.py`\n\n结果：全量审计通过，统一测试 7/7 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit sandbox planning phase to story generation, automatically organizing locations, NPCs, tools, and interactive elements based on narrative beats.

* **Documentation**
  * Updated story pipeline documentation to reflect v4 generation flow with integrated sandbox topology planning.
  * Expanded story skeleton template with location and sandbox configuration guidance.

* **Tests**
  * Added validation tests for sandbox planning and playability verification.
  * Enhanced existing tests to confirm backward compatibility with legacy story formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->