### PR TITLE
[script/v7] NPC关系账本与终局前回咬 Pass 8

### DIFF
--- a/docs/tasks/TASK_NEXT_VN_SANDBOX_GOALS.md
+++ b/docs/tasks/TASK_NEXT_VN_SANDBOX_GOALS.md
@@ -22,8 +22,8 @@
 但它还没有达到目标里的 galgame / 视觉小说厚度。真正的问题不是再加几个吓人名词,而是三件事:
 
 1. 玩家选择对角色关系的影响还不够可见;
-2. 清洁工、论坛围观者、评价室已经完成第一轮人格化,但仍需要扩展到更多关键 NPC;
-3. VN 演出字段已经覆盖正式节点,关键节点开始补 `camera / cg_intent / transition_intent`,但还没有形成完整审计工具。
+2. 清洁工、论坛围观者、评价室已经完成第一轮人格化,Pass 8 已把三者推进为“曝光 / 删除 / 审判”的同一张 NPC 账本;
+3. VN 演出字段已经覆盖正式节点,关键节点已补 `camera / cg_intent / transition_intent`,并被 `audit_playability` 关键节点 warning 锁住。
 
 本任务记录下一阶段的目标,避免后续继续凭感觉修文本。
 
@@ -101,7 +101,7 @@
 
 ### M4: 工具债收敛
 
-状态: In Progress。Issue `#27` 已完成 audit_tree 孤儿道具口径修正与 audit_state 分级输出,剩余为全量验收和后续细项压缩。
+状态: Done for current baseline。Issue `#27` 已完成 audit_tree 孤儿道具口径修正与 audit_state 分级输出;Issue `#19` 已关闭并把 v4 生成器对齐拆到 `#23`;已完成的 `#31` / `#33` 也已关闭,当前 milestone 只剩 roadmap `#22` 与 v4 生成器对齐 `#23`。
 
 目标:
 
@@ -114,6 +114,23 @@
 - `audit_tree` 不再报告无意义孤儿道具;
 - `audit_state` 的输出能分出 error / warning / info;
 - Issue `#19` 状态与 Task 文档一致。
+
+### M5: 剧本 Pass 8 - NPC 关系账本与终局前回咬
+
+状态: Done,见 `docs/tasks/TASK_SCRIPT_NPC_ACCOUNTABILITY_PASS8.md` 与 GitHub Issue `#36`。
+
+目标:
+
+- 让论坛、清洁工、评价室不再只是功能节点,而是共同读取玩家取证、曝光、删痕、审判和命名行为;
+- 用既有 `arc.named_the_dead / oneshot.live_streaming / oneshot.s6_no_fingerprint / arc.got_judge_seal / route.behavior_self_audit` 建立终局前回咬;
+- 保持开放沙盒和 DB schema 不变。
+
+验收:
+
+- `n_npc_forum_lurkers` 写入命名死者状态;
+- `n_npc_cleaner_null`、`n_scene_b3_corridor`、`n_scene_evaluator_room`、`n_scene_morning_lakeside` 读取 NPC 账本状态;
+- 新增 `tests/test_npc_accountability_pass8.py`;
+- `audit_all` 与统一测试通过。
 
 ---
 

--- a/docs/tasks/TASK_SCRIPT_NPC_ACCOUNTABILITY_PASS8.md
+++ b/docs/tasks/TASK_SCRIPT_NPC_ACCOUNTABILITY_PASS8.md
@@ -1,0 +1,137 @@
+# TASK: 正式剧本 NPC 关系账本与终局前回咬 Pass 8
+
+版本: v1.0
+状态: Done
+关联:
+- Milestone: `v7 VN 沙盒可玩闭环`
+- GitHub Issue: `#36`
+- `docs/tasks/TASK_NEXT_VN_SANDBOX_GOALS.md`
+- `docs/tasks/TASK_SCRIPT_BEHAVIOR_FEEDBACK_PASS6.md`
+- `docs/tasks/TASK_VN_PRESENTATION_CONTRACT_PASS7.md`
+
+---
+
+## 0. 背景
+
+Pass 4-7 已经把主角身份、玩家行为画像、工具回访和 VN 演出契约推进到可审计状态。
+
+但正式剧本还有一个核心体验缺口:共享 NPC 仍然更像功能菜单,不是会记账的角色。论坛负责曝光,清洁工负责删除痕迹,评价室负责审判,三者本该构成同一套“身份与责任系统”,现在联系还不够硬。
+
+本轮目标是把玩家在取证、曝光、删痕、等待系统、救人、避险中的选择,提前反咬到论坛 / 清洁工 / 评价室 / B3 / 晨湖,让玩家在终局前看见自己被 NPC 记账。
+
+---
+
+## 1. 目标 / 非目标
+
+### 目标
+
+- [x] 强化 `n_npc_forum_lurkers`:论坛不只是加 PR,而是区分“命名死者”和“把死者剪成素材”;
+- [x] 强化 `n_npc_cleaner_null`:清洁工不只是删道具,而是读取直播、照片、无指纹、砸监控等身份痕迹;
+- [x] 强化 `n_npc_evaluator_chair` / `n_scene_evaluator_room`:评价室按案由审玩家,不再只像结局按钮房;
+- [x] 强化至少 2 个终局前节点对 NPC 账本的回咬,优先 `n_scene_b3_corridor` 与 `n_scene_morning_lakeside`;
+- [x] 复用现有 `flags / puzzle / theme / deductions / PR / GR`,不新增 DB schema;
+- [x] 重建正式 `tree.json`,并通过全量审计与统一测试。
+
+### 非目标
+
+- 不引入通用好感度系统;
+- 不新增真实图片 / 音频资产;
+- 不新增数据库 schema;
+- 不把开放沙盒改成线性章节;
+- 不为每个 NPC 新建独立数值轨道。
+
+---
+
+## 2. 设计约束
+
+### 2.1 状态复用
+
+优先复用这些既有状态:
+
+- 曝光 / 传播: `oneshot.posted_photo`, `oneshot.forum_posted`, `oneshot.live_streaming`, `arc.s1_post_forum`, `oneshot.s4_posted_blood_face`, `arc.all_archives_photoed`;
+- 删除 / 身份痕迹: `oneshot.s4_smashed_monitor`, `oneshot.s6_no_fingerprint`, `oneshot.sacrificed_id`;
+- 审判 / 案由: `arc.got_judge_seal`, `piece_judge_seal`, `arc.s4_refused_yanggui`, `arc.s3_refused_h1987`, `arc.s6_replaced_seven`, `oneshot.defied_token`;
+- 救人与命名: `oneshot.s5_freed_yeh`, `arc.seven_returned`, `arc.redgirl_trusts_zhao`, `arc.named_the_dead`, `know.claimed_linmou`;
+- 避险 / 等待系统: `shifts_skipped_min`, `know.phone_called_1987`, `route.behavior_self_audit`;
+- 现实压力: `arc.rent_pressure`。
+
+### 2.2 Good Taste 红线
+
+- 新增文本可以多,新增状态必须少;
+- 同一节点 `narrative_variants` 不应无限膨胀,优先修改已有 variant 文本和少量补关键 variant;
+- 选择效果必须和行为一致,不能出现“不去评价室也拿审判章”这类因果错位;
+- 改 fragment 后必须运行 `tools/merge_fragments.py`,以正式 `tree.json` 为验收对象。
+
+---
+
+## 3. 里程碑
+
+### M1: 论坛与清洁工账本
+
+- [x] 论坛区分“更正命名 / 继续直播 / 删帖 / 回 G-272”四种姿态;
+- [x] 清洁工读取直播、档案照片、无指纹、砸监控、工牌献祭等痕迹;
+- [x] 清洁工选择文本从“删某个道具”升级为“清理某类身份痕迹”。
+
+### M2: 评价室案由化
+
+- [x] `n_npc_evaluator_chair` narrative variants 明确案由,不是通用授章通知;
+- [x] `n_scene_evaluator_room` 补充至少 2 条 NPC 账本相关 variant;
+- [x] 修正选择文案和 effects 的因果,确保只有真正进入报到才获得 `arc.got_judge_seal`。
+
+### M3: 终局前回咬
+
+- [x] `n_scene_b3_corridor` 新增或强化论坛/清洁工/评价室联动判词;
+- [x] `n_scene_morning_lakeside` 新增或强化 NPC 账本回收;
+- [x] 至少 3 类玩家姿态能在终局前被 NPC 或系统点名。
+
+### M4: 验收与同步
+
+- [x] 更新团队评审文档;
+- [x] 重建 `stories/hangzhou_yebanbaoan/tree.json`;
+- [x] `python3 -m json.tool stories/hangzhou_yebanbaoan/_fragment_v7_shared.json >/dev/null`;
+- [x] `python3 tools/merge_fragments.py`;
+- [x] `bash tools/audit_all.sh`;
+- [x] `.venv/bin/python tools/run_all_tests.py`;
+- [x] 回写 GitHub Issue 与本 Task。
+
+---
+
+## 4. 验收标准
+
+- 正式树节点数保持稳定或有明确解释;
+- `audit_variants` 保持 `undifferentiated_revisit_nodes: []`;
+- `audit_playability` 无 error,关键演出意图 warning 不回归;
+- 至少 5 个正式节点新增或强化“NPC 账本 / 终局前回咬”文本;
+- 不新增 DB schema;
+- 不新增未注册资源引用。
+
+---
+
+## 5. 完成记录
+
+本轮完成 Pass 8 最小闭环:
+
+- `n_npc_forum_lurkers` 的“这些不是素材,是名字”现在写入既有 `arc.named_the_dead`;
+- `n_npc_cleaner_null` 增加直播 + 命名、工牌献祭后的身份清理反馈;
+- `n_npc_evaluator_chair` 与 `n_scene_evaluator_room` 增加论坛更正帖 / 无指纹但仍需签名的案由;
+- `n_scene_b3_corridor` 增加论坛、清洁工、评价室三列账本判词;
+- `n_scene_morning_lakeside` 增加回看路线 + 命名、无指纹 + 候补判官章的终局前回收;
+- 新增 `tests/test_npc_accountability_pass8.py`,并接入 `tools/run_all_tests.py`。
+
+已验证:
+
+- `python3 -m json.tool stories/hangzhou_yebanbaoan/_fragment_v7_shared.json >/dev/null`;
+- `python3 tools/merge_fragments.py`;
+- `python3 tools/audit_playability.py stories/hangzhou_yebanbaoan/tree.json`;
+- `python3 tools/audit_variants.py stories/hangzhou_yebanbaoan/tree.json --strict`;
+- `bash tools/audit_all.sh`;
+- `.venv/bin/python tools/run_all_tests.py`。
+
+结果:
+
+- 正式树节点数保持 `145`;
+- 结局节点保持 `21`;
+- variants 总数从 `309` 提升到 `319`;
+- `undifferentiated_revisit_nodes: []`;
+- `audit_playability` 无 error / warning;
+- 统一测试 `7/7` 通过。

--- a/docs/team-reviews/2026-05-09-npc-accountability-pass8.md
+++ b/docs/team-reviews/2026-05-09-npc-accountability-pass8.md
@@ -1,0 +1,113 @@
+# 2026-05-09 Pass 8 NPC 关系账本与终局前回咬团队评审
+
+关联 Task: `docs/tasks/TASK_SCRIPT_NPC_ACCOUNTABILITY_PASS8.md`
+关联 Issue: `#36`
+
+---
+
+## 0. 结论
+
+【核心判断】
+✅ 值得做。当前剧本已经能跑,但共享 NPC 的“记账感”仍不够硬。论坛、清洁工、评价室分别代表传播、删除、审判,它们应该读同一组玩家行为,形成一套可感知的身份系统。
+
+【关键洞察】
+- 数据结构:现有 `flags / puzzle / PR / GR / narrative_variants` 已够用,不需要新增好感度或 DB schema;
+- 复杂度:不要造“NPC 关系系统”,只把已有行为状态在关键 NPC 和终局前节点读出来;
+- 风险点:最危险的是新增一堆镜像 flag,把状态空间变脏。
+
+---
+
+## 1. 剧本主笔
+
+当前最薄弱的不是恐怖意象,而是 NPC 对玩家行为的态度还不够持续。论坛、清洁工、评价室都应该能说出玩家“今晚到底把死人当人,还是当素材”。
+
+建议优先改:
+- `n_npc_forum_lurkers`
+- `n_npc_cleaner_null`
+- `n_npc_evaluator_chair`
+- `n_scene_evaluator_room`
+- `n_scene_b3_corridor`
+- `n_scene_morning_lakeside`
+
+---
+
+## 2. 玩法设计
+
+玩家不需要看到数值面板。玩家需要看到后果。
+
+Pass 8 应该复用现有行为输入:
+- 取证: `arc.all_archives_photoed`
+- 曝光: `oneshot.posted_photo`, `oneshot.live_streaming`, `oneshot.forum_posted`
+- 删痕: `oneshot.s6_no_fingerprint`, `oneshot.sacrificed_id`
+- 等系统: `know.phone_called_1987`
+- 自审: `route.behavior_self_audit`
+- 救人/命名: `oneshot.s5_freed_yeh`, `arc.seven_returned`, `arc.named_the_dead`
+
+不要新增通用好感度。
+
+---
+
+## 3. 状态架构
+
+本轮不新增 DB schema。新增 flag 也要极度克制。
+
+允许:
+- 新增或修改 `narrative_variants`;
+- 修改 choice 文案;
+- 在必要时复用已有 effects。
+
+禁止:
+- 新增 NPC 好感度数值;
+- 新增一组 `npc.*.trust` 镜像状态;
+- 用新 flag 代替已有 `oneshot/arc/know` 状态。
+
+---
+
+## 4. UX
+
+文本过渡要像“被世界认出来”,不是像系统提示。
+
+好体验:
+- NPC 说出玩家刚才做过的具体事;
+- B3 或晨湖把玩家路线变成判词;
+- 结局前至少一次让玩家意识到“开放路线不是自由无痕,而是每一步都被记录”。
+
+坏体验:
+- HUD 直接宣布“你是曝光型玩家”;
+- NPC 重复解释规则;
+- 终局才突然结算。
+
+---
+
+## 5. VN 演出
+
+本轮主要改文本,但不能破坏 Pass 7 演出契约。
+
+关键节点已有 `camera / cg_intent / transition_intent`,只要不新增资源引用,审计应保持稳定。
+
+---
+
+## 6. QA
+
+必须跑:
+- `python3 -m json.tool stories/hangzhou_yebanbaoan/_fragment_v7_shared.json >/dev/null`
+- `python3 tools/merge_fragments.py`
+- `python3 tools/audit_playability.py stories/hangzhou_yebanbaoan/tree.json`
+- `bash tools/audit_all.sh`
+- `.venv/bin/python tools/run_all_tests.py`
+
+重点看:
+- dangling refs 不能新增;
+- orphan 口径不能回退;
+- `undifferentiated_revisit_nodes` 仍为空;
+- presentation intent warning 不能回归。
+
+---
+
+## 7. 发布/文档
+
+需要同步:
+- Task 文档状态;
+- Issue checklist / 评论;
+- `TASK_NEXT_VN_SANDBOX_GOALS.md` 的进度记录;
+- PR 描述写明“不新增 DB schema / 不新增真实素材”。

--- a/docs/team-reviews/INDEX.md
+++ b/docs/team-reviews/INDEX.md
@@ -22,6 +22,7 @@
 | 2026-05-08 | Pass 6 / VN 化大批量铺开(第 1+2 批 7 节点 + 引擎渲染层 P0) | 修改后放行(Meta 投不可放行,采纳 Topology 3 批分级 + UX render P0 + 绝对不动批化解) | [报告](2026-05-08-vn-bulk-rollout.md) |
 | 2026-05-09 | 项目级同步事务与团队评审留痕 | 修改后放行 | [报告](2026-05-09-project-sync-workflow.md) |
 | 2026-05-09 | VN 演出意图契约 Pass 7 | 修改后放行 | [报告](2026-05-09-vn-presentation-contract-pass7.md) |
+| 2026-05-09 | Pass 8 NPC 关系账本与终局前回咬 | 修改后放行 | [报告](2026-05-09-npc-accountability-pass8.md) |
 
 ---
 

--- a/stories/hangzhou_yebanbaoan/_fragment_v7_shared.json
+++ b/stories/hangzhou_yebanbaoan/_fragment_v7_shared.json
@@ -1671,6 +1671,23 @@
       "narrative_variants": [
         {
           "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "论坛刷新。\n\n你上一条更正帖没有爆。\n\n没有置顶,没有热榜,甚至没有几条评论。\n\n它只是安静地躺在夜班论坛第 27 页,标题很笨:\n\n「这些不是素材,是名字。」\n\n第一个匿名账号回复:\n\n「楼主,这样写没人看。」\n\n第二个匿名账号回复:\n\n「可我终于知道他们叫什么了。」\n\n第三个账号没有头像,ID 是 G-272。\n\n他只回了一个字:\n\n「够。」\n\n你忽然明白,论坛不是只能吞人。\n\n它也能留下很小、很慢、很不适合传播的东西。\n\n比如名字。"
+        },
+        {
+          "if": {
             "flags": {
               "arc.all_archives_photoed": true
             }
@@ -1721,7 +1738,8 @@
           "text": "只发一条更正:这些不是素材,是名字。",
           "effects": {
             "flags": {
-              "oneshot.forum_posted": true
+              "oneshot.forum_posted": true,
+              "arc.named_the_dead": true
             },
             "PR": 6,
             "GR": -2
@@ -1755,7 +1773,7 @@
           }
         },
         {
-          "text": "把手机摔了。",
+          "text": "把手机摔了,宁愿丢掉前任号码也不让论坛继续剪辑。",
           "next": "n_landmark_picker",
           "effects": {
             "GR": 8,
@@ -1791,6 +1809,23 @@
         "transition_intent": "judgement_summons"
       },
       "narrative_variants": [
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "你在夜班论坛写过一条更正帖。\n\n夜班评议会把它打印出来,夹进案卷。\n\n纸很薄。\n\n薄到几乎不像证据。\n\n但评议会还是给它盖了骑缝章:\n\n「案由四:赵某曾尝试阻止围观者把死者改写成素材。\n  证据:论坛更正帖、G-272 私信、未被热榜采纳的 27 个名字。\n  评议意见:无传播价值,有归档价值。」\n\n你看着最后一句,突然觉得评议会第一次不像怪物。\n\n它只是这座城市里少数还承认『没人看』也可以算完成的东西。"
+        },
         {
           "if": {
             "flags": {
@@ -2049,6 +2084,31 @@
       "narrative_variants": [
         {
           "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.live_streaming": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "清洁工出现在直播回放里。\n\n这一次,他没有立刻擦掉画面。\n\n他站在镜头边缘,像在等你说完。\n\n你上一条论坛更正帖的标题浮在他空白的脸上:\n\n「这些不是素材,是名字。」\n\n弹幕还在催你剪高潮片段。\n\n清洁工却把拖把横在手机屏幕前,把那些催促擦成一行雪花。\n\n他的雪花声从听筒里钻出来:\n\n「名字留下。\n  标题清掉。\n  这是两种清洁。」\n\n你第一次觉得他不是来删除真相。\n\n他是在问你:到底要删掉围观者,还是删掉人。"
+        },
+        {
+          "if": {
+            "flags": {
+              "oneshot.sacrificed_id": true
+            }
+          },
+          "text": "你已经把工牌交给过电视雪花。\n\n清洁工远远看着你,没有靠近。\n\n他的空桶里传出塑料卡片互相碰撞的声音。\n\n一张、两张、十一张。\n\n每一张都曾经挂在某个 G-273 胸前。\n\n他用拖把在空气里写:\n\n「工牌不是垃圾。\n  工牌是系统用来夹住人的夹子。\n  你把夹子交出去,它当然会替你清理名字。」\n\n你摸了摸胸口那两个小洞。\n\n清洁不是消失。\n\n清洁有时只是把你从赵某擦成一个岗位。"
+        },
+        {
+          "if": {
             "flags": {
               "oneshot.live_streaming": true
             }
@@ -2107,7 +2167,7 @@
           }
         },
         {
-          "text": "让他删掉你和前任之间最危险的联系。",
+          "text": "让他清理你在论坛和手机里留下的身份痕迹。",
           "next": "n_landmark_picker",
           "effects": {
             "GR": 5,
@@ -2528,6 +2588,50 @@
             "all_of": [
               {
                 "flags": {
+                  "oneshot.live_streaming": true
+                }
+              },
+              {
+                "flags": {
+                  "oneshot.s6_no_fingerprint": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.got_judge_seal": true
+                }
+              }
+            ]
+          },
+          "text": "你走进 B3 走廊。\n\n27 台电视没有播鬼影。\n\n它们分成三组。\n\n左边 9 台播放论坛弹幕,每一条都在问『下一段呢』。\n\n右边 9 台播放清洁工的拖把,每一帧都少掉一点你的脸。\n\n中间 9 台播放评价室案卷,每一页都写着同一句话:\n\n「已传播。\n  已清洁。\n  已获章。\n  责任仍未注销。」\n\n你站在三组屏幕中间,第一次看见这三个 NPC 原来在处理同一件事。\n\n论坛把人变成内容。\n\n清洁工把人变成空白。\n\n评议会把空白重新叫上庭。\n\n它们不是三条支线。\n\n它们是同一张账本的三列。"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.redgirl_trusts_zhao": true
+                }
+              }
+            ]
+          },
+          "text": "你走进 B3 走廊。\n\n第 14 台电视亮起。\n\n屏幕里不是林晓燕被剪成标题的画面。\n\n是一条很短的论坛更正帖。\n\n「她叫林晓燕。」\n\n这 5 个字在雪花里闪了 27 次。\n\n第 28 次,屏幕里那个抱电视的女孩终于抬头。\n\n她没有说谢谢。\n\n她只是把电视往怀里抱紧一点,像第一次确定自己不是一个素材编号。\n\nB3 的判词从墙上浮出来:\n\n「命名行为有效。\n  围观伤害降低。\n  后续仍需完成归档。」"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
                   "oneshot.s5_freed_yeh": true
                 }
               },
@@ -2688,6 +2792,40 @@
         "transition_intent": "case_review"
       },
       "narrative_variants": [
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "你走进档案室时,桌上已经放着那条论坛更正帖。\n\n它没有点赞截图。\n\n没有热榜排名。\n\n只有一个很丑的标题:\n\n「这些不是素材,是名字。」\n\n第 12 本空白记录表把它归在『低传播证据』一栏。\n\n旁边批注:\n\n「本栏通常为空。\n  因多数记录员更愿意提交爆款,不愿提交名字。」\n\n11 本前任记录表没有鼓掌。\n\n它们只是把蜡烛往中间挪了一厘米。\n\n那一厘米,够你看清桌上每一张证词的姓名栏。"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.s6_no_fingerprint": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.got_judge_seal": true
+                }
+              }
+            ]
+          },
+          "text": "你带着候补判官章走进档案室。\n\n但第 12 本空白记录表先检查的不是章。\n\n是你的手。\n\n指纹卡仍然一片干净。\n\n清洁工替你做过第一步:擦掉身份。\n\n评议会现在做第二步:确认你是否还愿意承担被擦掉之前做过的事。\n\n纸页上慢慢浮现:\n\n「无指纹者不得逃避签名。\n  无姓名者不得免除案由。」\n\n你把手按在记录表上。\n\n没有指纹。\n\n但纸背面渗出一个很浅的名字:\n\n赵某。"
+        },
         {
           "if": {
             "flags": {
@@ -3300,6 +3438,45 @@
       "_one_way": true,
       "_one_way_hint": "06:03 · 湖滨 — 夜班已经结束。回不去地图了。",
       "narrative_variants": [
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              },
+              {
+                "flags": {
+                  "route.behavior_self_audit": true
+                }
+              }
+            ]
+          },
+          "text": "06:03,湖滨。\n\n你回看过自己的路线,也发过那条没人爱看的更正帖。\n\n湖面上漂来一张很薄的纸。\n\n不是判决书。\n\n是论坛打印页。\n\n「这些不是素材,是名字。」\n\n纸角被水泡软,但 27 个名字没有糊。\n\n记录表在最后一栏补了一句:\n\n「玩家曾尝试把传播改回归档。\n  效果有限。\n  但有效。」\n\n这句话很克制。\n\n克制得像真正的好消息。\n\n因为这一夜终于有一件事没有靠热度证明自己。"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.s6_no_fingerprint": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.got_judge_seal": true
+                }
+              }
+            ]
+          },
+          "text": "06:03,湖滨。\n\n你伸手去摸湖水。\n\n湖面没有留下指纹。\n\n这本来很可怕。\n\n但胸袋里的候补判官章还在发热。\n\n记录表像知道你在想什么,自己翻到最后一页:\n\n「无指纹者仍可签名。\n  获章者仍需承担。\n  清洁不等于免责。」\n\n你把手从湖水里收回来。\n\n指尖空空的。\n\n可你第一次不急着证明自己存在。\n\n你只想把该负责的那几栏写完。"
+        },
         {
           "if": {
             "flags": {

--- a/stories/hangzhou_yebanbaoan/tree.json
+++ b/stories/hangzhou_yebanbaoan/tree.json
@@ -8732,6 +8732,23 @@
       "narrative_variants": [
         {
           "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "论坛刷新。\n\n你上一条更正帖没有爆。\n\n没有置顶,没有热榜,甚至没有几条评论。\n\n它只是安静地躺在夜班论坛第 27 页,标题很笨:\n\n「这些不是素材,是名字。」\n\n第一个匿名账号回复:\n\n「楼主,这样写没人看。」\n\n第二个匿名账号回复:\n\n「可我终于知道他们叫什么了。」\n\n第三个账号没有头像,ID 是 G-272。\n\n他只回了一个字:\n\n「够。」\n\n你忽然明白,论坛不是只能吞人。\n\n它也能留下很小、很慢、很不适合传播的东西。\n\n比如名字。"
+        },
+        {
+          "if": {
             "flags": {
               "arc.all_archives_photoed": true
             }
@@ -8782,7 +8799,8 @@
           "text": "只发一条更正:这些不是素材,是名字。",
           "effects": {
             "flags": {
-              "oneshot.forum_posted": true
+              "oneshot.forum_posted": true,
+              "arc.named_the_dead": true
             },
             "PR": 6,
             "GR": -2
@@ -8816,7 +8834,7 @@
           }
         },
         {
-          "text": "把手机摔了。",
+          "text": "把手机摔了,宁愿丢掉前任号码也不让论坛继续剪辑。",
           "next": "n_landmark_picker",
           "effects": {
             "GR": 8,
@@ -8852,6 +8870,23 @@
         "transition_intent": "judgement_summons"
       },
       "narrative_variants": [
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "你在夜班论坛写过一条更正帖。\n\n夜班评议会把它打印出来,夹进案卷。\n\n纸很薄。\n\n薄到几乎不像证据。\n\n但评议会还是给它盖了骑缝章:\n\n「案由四:赵某曾尝试阻止围观者把死者改写成素材。\n  证据:论坛更正帖、G-272 私信、未被热榜采纳的 27 个名字。\n  评议意见:无传播价值,有归档价值。」\n\n你看着最后一句,突然觉得评议会第一次不像怪物。\n\n它只是这座城市里少数还承认『没人看』也可以算完成的东西。"
+        },
         {
           "if": {
             "flags": {
@@ -9110,6 +9145,31 @@
       "narrative_variants": [
         {
           "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.live_streaming": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "清洁工出现在直播回放里。\n\n这一次,他没有立刻擦掉画面。\n\n他站在镜头边缘,像在等你说完。\n\n你上一条论坛更正帖的标题浮在他空白的脸上:\n\n「这些不是素材,是名字。」\n\n弹幕还在催你剪高潮片段。\n\n清洁工却把拖把横在手机屏幕前,把那些催促擦成一行雪花。\n\n他的雪花声从听筒里钻出来:\n\n「名字留下。\n  标题清掉。\n  这是两种清洁。」\n\n你第一次觉得他不是来删除真相。\n\n他是在问你:到底要删掉围观者,还是删掉人。"
+        },
+        {
+          "if": {
+            "flags": {
+              "oneshot.sacrificed_id": true
+            }
+          },
+          "text": "你已经把工牌交给过电视雪花。\n\n清洁工远远看着你,没有靠近。\n\n他的空桶里传出塑料卡片互相碰撞的声音。\n\n一张、两张、十一张。\n\n每一张都曾经挂在某个 G-273 胸前。\n\n他用拖把在空气里写:\n\n「工牌不是垃圾。\n  工牌是系统用来夹住人的夹子。\n  你把夹子交出去,它当然会替你清理名字。」\n\n你摸了摸胸口那两个小洞。\n\n清洁不是消失。\n\n清洁有时只是把你从赵某擦成一个岗位。"
+        },
+        {
+          "if": {
             "flags": {
               "oneshot.live_streaming": true
             }
@@ -9168,7 +9228,7 @@
           }
         },
         {
-          "text": "让他删掉你和前任之间最危险的联系。",
+          "text": "让他清理你在论坛和手机里留下的身份痕迹。",
           "next": "n_landmark_picker",
           "effects": {
             "GR": 5,
@@ -9618,6 +9678,50 @@
             "all_of": [
               {
                 "flags": {
+                  "oneshot.live_streaming": true
+                }
+              },
+              {
+                "flags": {
+                  "oneshot.s6_no_fingerprint": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.got_judge_seal": true
+                }
+              }
+            ]
+          },
+          "text": "你走进 B3 走廊。\n\n27 台电视没有播鬼影。\n\n它们分成三组。\n\n左边 9 台播放论坛弹幕,每一条都在问『下一段呢』。\n\n右边 9 台播放清洁工的拖把,每一帧都少掉一点你的脸。\n\n中间 9 台播放评价室案卷,每一页都写着同一句话:\n\n「已传播。\n  已清洁。\n  已获章。\n  责任仍未注销。」\n\n你站在三组屏幕中间,第一次看见这三个 NPC 原来在处理同一件事。\n\n论坛把人变成内容。\n\n清洁工把人变成空白。\n\n评议会把空白重新叫上庭。\n\n它们不是三条支线。\n\n它们是同一张账本的三列。"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.redgirl_trusts_zhao": true
+                }
+              }
+            ]
+          },
+          "text": "你走进 B3 走廊。\n\n第 14 台电视亮起。\n\n屏幕里不是林晓燕被剪成标题的画面。\n\n是一条很短的论坛更正帖。\n\n「她叫林晓燕。」\n\n这 5 个字在雪花里闪了 27 次。\n\n第 28 次,屏幕里那个抱电视的女孩终于抬头。\n\n她没有说谢谢。\n\n她只是把电视往怀里抱紧一点,像第一次确定自己不是一个素材编号。\n\nB3 的判词从墙上浮出来:\n\n「命名行为有效。\n  围观伤害降低。\n  后续仍需完成归档。」"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
                   "oneshot.s5_freed_yeh": true
                 }
               },
@@ -9778,6 +9882,40 @@
         "transition_intent": "case_review"
       },
       "narrative_variants": [
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              }
+            ]
+          },
+          "text": "你走进档案室时,桌上已经放着那条论坛更正帖。\n\n它没有点赞截图。\n\n没有热榜排名。\n\n只有一个很丑的标题:\n\n「这些不是素材,是名字。」\n\n第 12 本空白记录表把它归在『低传播证据』一栏。\n\n旁边批注:\n\n「本栏通常为空。\n  因多数记录员更愿意提交爆款,不愿提交名字。」\n\n11 本前任记录表没有鼓掌。\n\n它们只是把蜡烛往中间挪了一厘米。\n\n那一厘米,够你看清桌上每一张证词的姓名栏。"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.s6_no_fingerprint": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.got_judge_seal": true
+                }
+              }
+            ]
+          },
+          "text": "你带着候补判官章走进档案室。\n\n但第 12 本空白记录表先检查的不是章。\n\n是你的手。\n\n指纹卡仍然一片干净。\n\n清洁工替你做过第一步:擦掉身份。\n\n评议会现在做第二步:确认你是否还愿意承担被擦掉之前做过的事。\n\n纸页上慢慢浮现:\n\n「无指纹者不得逃避签名。\n  无姓名者不得免除案由。」\n\n你把手按在记录表上。\n\n没有指纹。\n\n但纸背面渗出一个很浅的名字:\n\n赵某。"
+        },
         {
           "if": {
             "flags": {
@@ -10390,6 +10528,45 @@
       "_one_way": true,
       "_one_way_hint": "06:03 · 湖滨 — 夜班已经结束。回不去地图了。",
       "narrative_variants": [
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.forum_posted": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.named_the_dead": true
+                }
+              },
+              {
+                "flags": {
+                  "route.behavior_self_audit": true
+                }
+              }
+            ]
+          },
+          "text": "06:03,湖滨。\n\n你回看过自己的路线,也发过那条没人爱看的更正帖。\n\n湖面上漂来一张很薄的纸。\n\n不是判决书。\n\n是论坛打印页。\n\n「这些不是素材,是名字。」\n\n纸角被水泡软,但 27 个名字没有糊。\n\n记录表在最后一栏补了一句:\n\n「玩家曾尝试把传播改回归档。\n  效果有限。\n  但有效。」\n\n这句话很克制。\n\n克制得像真正的好消息。\n\n因为这一夜终于有一件事没有靠热度证明自己。"
+        },
+        {
+          "if": {
+            "all_of": [
+              {
+                "flags": {
+                  "oneshot.s6_no_fingerprint": true
+                }
+              },
+              {
+                "flags": {
+                  "arc.got_judge_seal": true
+                }
+              }
+            ]
+          },
+          "text": "06:03,湖滨。\n\n你伸手去摸湖水。\n\n湖面没有留下指纹。\n\n这本来很可怕。\n\n但胸袋里的候补判官章还在发热。\n\n记录表像知道你在想什么,自己翻到最后一页:\n\n「无指纹者仍可签名。\n  获章者仍需承担。\n  清洁不等于免责。」\n\n你把手从湖水里收回来。\n\n指尖空空的。\n\n可你第一次不急着证明自己存在。\n\n你只想把该负责的那几栏写完。"
+        },
         {
           "if": {
             "flags": {

--- a/tests/test_npc_accountability_pass8.py
+++ b/tests/test_npc_accountability_pass8.py
@@ -1,0 +1,78 @@
+"""Pass 8 NPC 关系账本回归测试。"""
+
+import json
+from pathlib import Path
+
+
+TREE_PATH = Path("stories/hangzhou_yebanbaoan/tree.json")
+
+
+def _tree():
+    return json.loads(TREE_PATH.read_text(encoding="utf-8"))
+
+
+def _variant_matches(variant, expected_flags):
+    """检查 narrative variant 是否读取指定 flag 集合。"""
+    cond = variant.get("if") or {}
+    clauses = cond.get("all_of") or [cond]
+    seen = {}
+    for clause in clauses:
+        seen.update(clause.get("flags") or {})
+    return all(seen.get(key) == value for key, value in expected_flags.items())
+
+
+def test_forum_correction_writes_named_dead_flag():
+    tree = _tree()
+    forum = tree["nodes"]["n_npc_forum_lurkers"]
+    correction = next(
+        choice for choice in forum["choices"] if choice["text"].startswith("只发一条更正")
+    )
+    assert correction["effects"]["flags"]["oneshot.forum_posted"] is True
+    assert correction["effects"]["flags"]["arc.named_the_dead"] is True
+
+
+def test_cleaner_reads_forum_naming_accountability():
+    tree = _tree()
+    cleaner = tree["nodes"]["n_npc_cleaner_null"]
+
+    assert any(
+        _variant_matches(
+            variant,
+            {"oneshot.live_streaming": True, "arc.named_the_dead": True},
+        )
+        for variant in cleaner["narrative_variants"]
+    )
+
+
+def test_b3_reads_forum_cleaner_and_evaluator_ledger():
+    tree = _tree()
+    b3 = tree["nodes"]["n_scene_b3_corridor"]
+
+    assert any(
+        _variant_matches(
+            variant,
+            {
+                "oneshot.live_streaming": True,
+                "oneshot.s6_no_fingerprint": True,
+                "arc.got_judge_seal": True,
+            },
+        )
+        for variant in b3["narrative_variants"]
+    )
+
+
+def test_morning_lakeside_reads_self_audit_and_naming():
+    tree = _tree()
+    lakeside = tree["nodes"]["n_scene_morning_lakeside"]
+
+    assert any(
+        _variant_matches(
+            variant,
+            {
+                "oneshot.forum_posted": True,
+                "arc.named_the_dead": True,
+                "route.behavior_self_audit": True,
+            },
+        )
+        for variant in lakeside["narrative_variants"]
+    )

--- a/tools/run_all_tests.py
+++ b/tools/run_all_tests.py
@@ -118,6 +118,7 @@ def main():
             [
                 "tests/test_view_tree_progress.py",
                 "tests/test_audit_playability.py",
+                "tests/test_npc_accountability_pass8.py",
             ],
         ),
         (


### PR DESCRIPTION
Closes #36

## 变更
- 论坛“这些不是素材,是名字”现在写入既有 arc.named_the_dead。
- 清洁工读取直播 + 命名、工牌献祭后的身份清理反馈。
- 评价室把论坛更正帖与无指纹但仍需签名纳入案由。
- B3 与晨湖增加 NPC 账本终局前回咬。
- 新增 tests/test_npc_accountability_pass8.py，并接入 tools/run_all_tests.py。

## 验证
- python3 -m json.tool stories/hangzhou_yebanbaoan/_fragment_v7_shared.json >/dev/null
- python3 tools/merge_fragments.py
- python3 tools/audit_playability.py stories/hangzhou_yebanbaoan/tree.json
- python3 tools/audit_variants.py stories/hangzhou_yebanbaoan/tree.json --strict
- bash tools/audit_all.sh
- .venv/bin/python tools/run_all_tests.py

## 约束
- 不新增 DB schema。
- 不新增真实图片 / 音频资产。
- 正式树节点数保持 145，结局节点保持 21。