### PR TITLE
[v4] 接入 GameTreePlan 沙盒骨架审计

### DIFF
--- a/docs/tasks/TASK_V4_GAMETREE_ALIGNMENT.md
+++ b/docs/tasks/TASK_V4_GAMETREE_ALIGNMENT.md
@@ -1,7 +1,7 @@
 # TASK: v4 生成器对齐 GameTree v1 沙盒拓扑
 
-版本: v0.2
-状态: Active
+版本: v1.0
+状态: Done
 关联:
 - `docs/tasks/TASK_GAMETREE_V1.md`
 - `docs/tasks/TASK_STORY_STRUCTURE.md`
@@ -35,8 +35,8 @@
 - [x] 扩展 `PlotSkeleton` 数据模型,让 beat 能表达沙盒所需的最小定位信息;
 - [x] 更新 `plot-skeleton.prompt.md`,要求 LLM 输出地标、NPC、工具节点和演出提示;
 - [x] 增加一个 `GameTreePlan` 或等价中间层,把骨架大纲转成 `GameTree v1` 形状前的结构计划;
-- [ ] 让生成链路产物能被 `audit_playability.py` 和后续 `audit_sandbox.py` 检查;
-- [ ] 保持 v3 legacy / 当前手写 v7 正式树兼容。
+- [x] 让生成链路产物能被 `audit_playability.py` 和后续 `audit_sandbox.py` 检查;
+- [x] 保持 v3 legacy / 当前手写 v7 正式树兼容。
 
 ### 非目标
 
@@ -100,9 +100,9 @@
 
 ### M4: 审计接入
 
-- [ ] 让 `GameTreePlan` 或其导出树能被 `audit_playability.py` 检查;
-- [ ] 新增 `audit_sandbox.py` 或扩展现有审计,验证 ADR-010 最小沙盒骨架;
-- [ ] 将相关测试挂入 `tools/run_all_tests.py`。
+- [x] 让 `GameTreePlan` 或其导出树能被 `audit_playability.py` 检查;
+- [x] 新增 `audit_sandbox.py` 或扩展现有审计,验证 ADR-010 最小沙盒骨架;
+- [x] 将相关测试挂入 `tools/run_all_tests.py`。
 
 ---
 
@@ -126,3 +126,31 @@
 - 新增 `pregenerator/gametree_plan.py`,把内容骨架转换成计划层的 `locations / tools / npc_routes / beats / presentation_defaults / acceptance`;
 - `GameTreePlan.to_minimal_tree()` 只用于内存测试和后续生成器对齐,不写正式树、不改 DB schema、不接入正式审计链;
 - M4 仍保留为后续工作:新增或接入 `audit_sandbox.py`,并决定何时挂入 `tools/run_all_tests.py`。
+
+### 2026-05-09: M4 审计接入收口
+
+- 新增 `tools/audit_sandbox.py`,按 ADR-010 检查 picker hub / landmark connections / tool / stay 自循环 / 反应式 variant;
+- `tools/audit_all.sh` 已接入 `audit_sandbox`,正式杭州树报告:
+  - picker hub: `3`;
+  - 地标: `11`;
+  - 工具节点: `10`;
+  - stay 自循环工具: `9`;
+  - 反应 variant 节点: `14`;
+- `GameTreePlan.to_minimal_tree()` 补齐最小结局、静态 picker 选项、地标实际跳转、工具退出、反应契约 resolver;
+- 新增 `tests/test_audit_sandbox.py`;
+- 更新 `tests/test_gametree_plan.py`,要求最小导出树同时通过基本可玩性、沙盒骨架和反应契约红线;
+- `tools/run_all_tests.py` 已挂入新测试。
+
+已验证:
+
+- `.venv/bin/python -m pytest tests/test_audit_sandbox.py tests/test_gametree_plan.py -q`;
+- `python3 tools/audit_sandbox.py stories/hangzhou_yebanbaoan/tree.json`;
+- `bash tools/audit_all.sh`;
+- `.venv/bin/python tools/run_all_tests.py`。
+
+结果:
+
+- 正式树仍为 `145` 节点、`21` 结局;
+- `audit_all` 全套 `7/7` 审计通过;
+- 统一测试 `7/7` 通过;
+- 未改 DB schema,未改正式杭州剧本拓扑。

--- a/docs/team-reviews/2026-05-09-v4-sandbox-audit.md
+++ b/docs/team-reviews/2026-05-09-v4-sandbox-audit.md
@@ -1,0 +1,70 @@
+# 2026-05-09 v4 GameTreePlan 沙盒骨架审计接入团队评审
+
+关联 Task: `docs/tasks/TASK_V4_GAMETREE_ALIGNMENT.md`
+关联 Issue: `#23`
+
+---
+
+## 0. 结论
+
+【核心判断】
+✅ 值得做。`GameTreePlan` 已经能产出最小可玩树,但“能跑”不等于“是沙盒”。ADR-010 已经把沙盒最小骨架写清楚,必须有机器守门。
+
+【关键洞察】
+- 数据结构: `PlotSkeleton` 继续做内容大纲,`GameTreePlan` 才承接沙盒拓扑计划;
+- 复杂度: `audit_sandbox.py` 只检查沙盒骨架,不重复 `audit_playability / audit_reactions / audit_variants`;
+- 风险点:如果 `audit_reactions.py` 不理解动态 picker,`GameTreePlan` 导出树必须同时给静态选项,不能靠测试豁免。
+
+---
+
+## 1. 架构评审
+
+新增 `audit_sandbox.py` 是正确边界:
+
+- `audit_playability.py`:能否跑通、坏跳转、死路、presentation 资产;
+- `audit_sandbox.py`:是否满足 ADR-010 沙盒骨架;
+- `audit_reactions.py`:反应契约注册与 resolver 可达;
+- `audit_variants.py`:重访是否有分化。
+
+工具职责没有混成一个大泥球。
+
+---
+
+## 2. 生成链路评审
+
+`GameTreePlan.to_minimal_tree()` 必须比“测试样例”更认真:
+
+- 补最小 ending;
+- 顶层 `endings` 注册;
+- picker 保留动态 `_is_map_picker`,同时提供静态地标入口,让通用 BFS 工具可验证;
+- 地标连接变成实际 choice;
+- 工具节点保留 `stay: true` 自循环,但也能回地图或结束调查;
+- 反应 variant 有 `reaction_contracts.deductions.sandbox_probe.resolver_node`。
+
+这让 v4 导出树开始像 GameTree v1,不是一张假地图。
+
+---
+
+## 3. QA
+
+新增测试覆盖:
+
+- `GameTreePlan` 最小导出树通过 sandbox audit;
+- 正式杭州树通过 sandbox audit;
+- 缺 picker / 地标 / 工具 / stay / 反应 clause 的线性树失败;
+- `GameTreePlan` 最小导出树有真实结局、真实地标跳转和反应契约声明。
+
+全量验证:
+
+- `.venv/bin/python -m pytest tests/test_audit_sandbox.py tests/test_gametree_plan.py -q`;
+- `python3 tools/audit_sandbox.py stories/hangzhou_yebanbaoan/tree.json`;
+- `bash tools/audit_all.sh`;
+- `.venv/bin/python tools/run_all_tests.py`。
+
+---
+
+## 4. 风险
+
+- `audit_sandbox.py` 不检查文案质量,这是故意的。文案质量属于剧本评审和正式树审计,不是拓扑骨架工具;
+- 正式生成器还没有把 `GameTreePlan` 产物写入最终故事文件,后续如果接生产链路,需要单独任务;
+- 现有 `audit_reactions.py` 仍是静态 BFS,因此导出树需要静态 choices 配合动态 picker。

--- a/docs/team-reviews/INDEX.md
+++ b/docs/team-reviews/INDEX.md
@@ -23,6 +23,7 @@
 | 2026-05-09 | 项目级同步事务与团队评审留痕 | 修改后放行 | [报告](2026-05-09-project-sync-workflow.md) |
 | 2026-05-09 | VN 演出意图契约 Pass 7 | 修改后放行 | [报告](2026-05-09-vn-presentation-contract-pass7.md) |
 | 2026-05-09 | Pass 8 NPC 关系账本与终局前回咬 | 修改后放行 | [报告](2026-05-09-npc-accountability-pass8.md) |
+| 2026-05-09 | v4 GameTreePlan 沙盒骨架审计接入 | 修改后放行 | [报告](2026-05-09-v4-sandbox-audit.md) |
 
 ---
 

--- a/src/ghost_story_factory/pregenerator/gametree_plan.py
+++ b/src/ghost_story_factory/pregenerator/gametree_plan.py
@@ -97,6 +97,8 @@ class GameTreePlan:
         这个导出只服务 M3 单元测试和后续生成器对齐,不是最终剧本。
         """
         picker_node_id = "n_map_picker"
+        ending_node_id = "n_end_sandbox_probe"
+        ending_type = "E_SANDBOX_PROBE"
         backgrounds = {"text_fallback": {"text_fallback": "文本演出兜底"}}
         nodes: Dict[str, Dict[str, Any]] = {
             self.start_node: {
@@ -112,10 +114,19 @@ class GameTreePlan:
                 "choices": [],
                 "presentation": {"background": "text_fallback"},
             },
+            ending_node_id: {
+                "node_id": ending_node_id,
+                "narrative": "沙盒探针结束。",
+                "choices": [],
+                "is_ending": True,
+                "ending_type": ending_type,
+                "presentation": {"background": "text_fallback"},
+            },
         }
 
         landmark_map: List[Dict[str, Any]] = []
         tool_by_location: Dict[str, List[ToolPlan]] = {}
+        location_by_id = {location.id: location for location in self.locations}
         for tool in self.tools:
             tool_by_location.setdefault(tool.location_id, []).append(tool)
 
@@ -129,9 +140,21 @@ class GameTreePlan:
                     "connections": list(location.connections),
                 }
             )
+            nodes[picker_node_id]["choices"].append(
+                {"text": f"前往 {location.label}", "next": node_id}
+            )
             choices: List[Dict[str, Any]] = []
             for tool in tool_by_location.get(location.id, []):
                 choices.append({"text": f"检查 {tool.id}", "next": f"n_{_slug(tool.id)}"})
+            for connected_id in location.connections:
+                connected = location_by_id.get(connected_id)
+                if connected:
+                    choices.append(
+                        {
+                            "text": f"前往 {connected.label}",
+                            "next": f"n_loc_{_slug(connected.id)}",
+                        }
+                    )
             if not choices:
                 choices.append({"text": "回到地图", "next": picker_node_id})
             presentation = self.presentation_defaults.get(
@@ -159,10 +182,13 @@ class GameTreePlan:
                         "text": "继续检查",
                         "next": node_id,
                         "effects": {"stay": True},
-                    }
+                    },
+                    {"text": "回到地图", "next": picker_node_id},
                 ],
                 "presentation": presentation,
             }
+            if index == len(self.tools) - 1:
+                node["choices"].append({"text": "结束调查", "next": ending_node_id})
             if index == 0:
                 node["narrative_variants"] = [
                     {
@@ -186,13 +212,22 @@ class GameTreePlan:
                 }
                 for tool in self.tools
             },
-            "endings": {},
+            "endings": {
+                ending_type: "沙盒探针结局",
+            },
             "assets": {
                 "backgrounds": backgrounds,
             },
             "reaction_contracts": {
                 "deductions": {
-                    "sandbox_probe": {"label": "沙盒探针"}
+                    "sandbox_probe": {
+                        "label": "沙盒探针",
+                        "resolver_node": ending_node_id,
+                        "consumer_nodes": [
+                            f"n_{_slug(self.tools[0].id)}"
+                        ] if self.tools else [],
+                        "trigger_type": "cross_run",
+                    }
                 },
                 "foreshadows": {},
                 "themes": {},

--- a/tests/test_audit_sandbox.py
+++ b/tests/test_audit_sandbox.py
@@ -1,0 +1,58 @@
+"""ADR-010 沙盒骨架审计测试。"""
+
+import json
+from pathlib import Path
+
+from ghost_story_factory.pregenerator.gametree_plan import GameTreePlan
+from tests.test_gametree_plan import _sandbox_skeleton
+from tools.audit_sandbox import analyze_sandbox
+
+
+def test_gametree_plan_minimal_tree_passes_sandbox_audit():
+    """GameTreePlan 的内存导出必须满足最小沙盒骨架。"""
+    plan = GameTreePlan.from_skeleton(_sandbox_skeleton())
+    report = analyze_sandbox(plan.to_minimal_tree())
+
+    assert report.ok
+    assert len(report.picker_nodes) == 1
+    assert report.landmark_count == 4
+    assert len(report.tool_nodes) == 2
+    assert report.stay_loop_nodes
+    assert report.reaction_variant_nodes
+
+
+def test_official_hangzhou_tree_passes_sandbox_audit():
+    """正式杭州树必须继续满足 ADR-010 沙盒骨架。"""
+    tree = json.loads(Path("stories/hangzhou_yebanbaoan/tree.json").read_text(encoding="utf-8"))
+    report = analyze_sandbox(tree)
+
+    assert report.ok
+    assert report.landmark_count >= 4
+    assert len(report.tool_nodes) >= 2
+
+
+def test_missing_sandbox_primitives_fail():
+    """缺少沙盒原语的线性树必须失败。"""
+    tree = {
+        "start_node": "n_intro",
+        "nodes": {
+            "n_intro": {
+                "narrative": "开始。",
+                "choices": [{"text": "下一步", "next": "n_end"}],
+                "presentation": {"background": "text"},
+            },
+            "n_end": {
+                "narrative": "结束。",
+                "is_ending": True,
+                "ending_type": "E_BAD",
+                "presentation": {"background": "text"},
+            },
+        },
+    }
+
+    report = analyze_sandbox(tree)
+
+    assert not report.ok
+    assert any("picker" in error for error in report.errors)
+    assert any("地标数量不足" in error for error in report.errors)
+    assert any("工具节点数量不足" in error for error in report.errors)

--- a/tests/test_gametree_plan.py
+++ b/tests/test_gametree_plan.py
@@ -1,5 +1,7 @@
 """GameTreePlan 草案单元测试。"""
 
+import json
+
 from ghost_story_factory.pregenerator.gametree_plan import GameTreePlan
 from ghost_story_factory.pregenerator.skeleton_model import (
     ActConfig,
@@ -9,6 +11,7 @@ from ghost_story_factory.pregenerator.skeleton_model import (
     SkeletonConfig,
 )
 from tools.audit_playability import analyze_playability
+from tools.audit_reactions import audit as audit_reactions
 
 
 def _sandbox_skeleton() -> PlotSkeleton:
@@ -99,9 +102,11 @@ def test_gametree_plan_minimal_tree_passes_playability_redlines():
 
     assert report.ok
     assert report.dynamic_picker_nodes == 1
+    assert report.ending_nodes == 1
     assert report.reachable_nodes == report.total_nodes
     assert len(tree["landmark_map"]) == 4
     assert len(tree["tools"]) == 2
+    assert "E_SANDBOX_PROBE" in tree["endings"]
     assert any(
         choice.get("effects", {}).get("stay")
         for node in tree["nodes"].values()
@@ -112,3 +117,34 @@ def test_gametree_plan_minimal_tree_passes_playability_redlines():
         for node in tree["nodes"].values()
         for variant in node.get("narrative_variants", [])
     )
+
+
+def test_gametree_plan_minimal_tree_has_real_navigation_edges():
+    """地标连接应既存在于 landmark_map,也能转成实际可走 choice。"""
+    plan = GameTreePlan.from_skeleton(_sandbox_skeleton())
+    tree = plan.to_minimal_tree()
+    location_nodes = {
+        landmark["id"]: tree["nodes"][landmark["node_id"]]
+        for landmark in tree["landmark_map"]
+    }
+
+    assert any(
+        choice["next"] == "n_loc_s2_lobby"
+        for choice in location_nodes["S1_security_room"]["choices"]
+    )
+
+
+def test_gametree_plan_minimal_tree_reactions_are_declared(tmp_path):
+    """导出的反应 variant 必须有 resolver_node,不能只是孤立消费。"""
+    plan = GameTreePlan.from_skeleton(_sandbox_skeleton())
+    path = tmp_path / "tree.json"
+    path.write_text(json.dumps(plan.to_minimal_tree(), ensure_ascii=False), encoding="utf-8")
+
+    report = audit_reactions(path)
+    blockers = [
+        problem
+        for problem in report["problems"]
+        if problem["code"] in ("DEAD_REACTION", "UNREACHABLE_REACTION")
+    ]
+
+    assert blockers == []

--- a/tools/audit_all.sh
+++ b/tools/audit_all.sh
@@ -5,23 +5,26 @@ set -e
 
 TREE="stories/hangzhou_yebanbaoan/tree.json"
 
-echo "=== 1/6 audit_playability(GameTree 可玩闭环)==="
+echo "=== 1/7 audit_playability(GameTree 可玩闭环)==="
 python tools/audit_playability.py "$TREE"
 echo
-echo "=== 2/6 audit_tree(节点引用完整性 + lore 红线)==="
+echo "=== 2/7 audit_sandbox(ADR-010 沙盒骨架)==="
+python tools/audit_sandbox.py "$TREE"
+echo
+echo "=== 3/7 audit_tree(节点引用完整性 + lore 红线)==="
 python tools/audit_tree.py "$TREE"
 echo
-echo "=== 3/6 audit_state(flags / inv 引用矩阵)==="
+echo "=== 4/7 audit_state(flags / inv 引用矩阵)==="
 python tools/audit_state.py "$TREE"
 echo
-echo "=== 4/6 audit_variants(variant 覆盖矩阵 + 重访无分化)==="
+echo "=== 5/7 audit_variants(variant 覆盖矩阵 + 重访无分化)==="
 python tools/audit_variants.py "$TREE"
 echo
-echo "=== 5/6 audit_reactions(反应式 variant 三红线 ADR-008)==="
+echo "=== 6/7 audit_reactions(反应式 variant 三红线 ADR-008)==="
 python tools/audit_reactions.py "$TREE" > /dev/null
 echo "  反应契约审计通过"
 echo
-echo "=== 6/6 audit_paths_linmou(linmou 必死不变量 ADR-009)==="
+echo "=== 7/7 audit_paths_linmou(linmou 必死不变量 ADR-009)==="
 python tools/audit_paths_linmou.py "$TREE" > /dev/null
 echo "  必死不变量审计通过"
 echo

--- a/tools/audit_sandbox.py
+++ b/tools/audit_sandbox.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""ADR-010 沙盒骨架审计。
+
+本工具只检查 GameTree v1 是否具备最小沙盒拓扑:
+- picker hub;
+- landmark_map 网状地标;
+- tool 节点;
+- stay 自循环;
+- 反应式 narrative variant;
+- presentation 文本演出兜底。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Set
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from tools.audit_playability import choices_of, choice_targets, load_payload, node_map
+
+
+REACTION_KEYS = {
+    "deduction_resolved",
+    "foreshadow_resolved",
+    "theme_resolved",
+    "ending_seen",
+}
+
+
+@dataclass
+class SandboxReport:
+    """沙盒骨架审计结果。"""
+
+    tree_path: str = ""
+    node_count: int = 0
+    picker_nodes: List[str] = field(default_factory=list)
+    landmark_count: int = 0
+    tool_nodes: List[str] = field(default_factory=list)
+    stay_loop_nodes: List[str] = field(default_factory=list)
+    reaction_variant_nodes: List[str] = field(default_factory=list)
+    presentation_nodes: int = 0
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> Dict[str, Any]:
+        """转成 JSON 友好的报告。"""
+        return {
+            "ok": self.ok,
+            "tree_path": self.tree_path,
+            "node_count": self.node_count,
+            "picker_nodes": self.picker_nodes,
+            "landmark_count": self.landmark_count,
+            "tool_nodes": self.tool_nodes,
+            "stay_loop_nodes": self.stay_loop_nodes,
+            "reaction_variant_nodes": self.reaction_variant_nodes,
+            "presentation_nodes": self.presentation_nodes,
+            "errors": self.errors,
+            "warnings": self.warnings,
+        }
+
+
+def analyze_sandbox(payload: Dict[str, Any], tree_path: str = "") -> SandboxReport:
+    """审计一棵 GameTree v1 是否具备 ADR-010 最小沙盒骨架。"""
+    nodes = node_map(payload)
+    report = SandboxReport(tree_path=tree_path, node_count=len(nodes))
+    if not nodes:
+        report.errors.append("树中没有节点")
+        return report
+
+    _check_picker(nodes, report)
+    _check_landmarks(payload, nodes, report)
+    _check_tools(payload, nodes, report)
+    _check_reaction_variants(nodes, report)
+    _check_presentation(nodes, report)
+    return report
+
+
+def _check_picker(nodes: Dict[str, Dict[str, Any]], report: SandboxReport) -> None:
+    """检查 picker hub。"""
+    report.picker_nodes = sorted(
+        node_id for node_id, node in nodes.items() if node.get("_is_map_picker")
+    )
+    if not report.picker_nodes:
+        report.errors.append("缺少 _is_map_picker=true 的 picker hub")
+
+
+def _check_landmarks(
+    payload: Dict[str, Any],
+    nodes: Dict[str, Dict[str, Any]],
+    report: SandboxReport,
+) -> None:
+    """检查 landmark_map 网状地标。"""
+    landmark_map = payload.get("landmark_map") or []
+    if not isinstance(landmark_map, list):
+        report.errors.append("landmark_map 必须是数组")
+        return
+
+    report.landmark_count = len(landmark_map)
+    if report.landmark_count < 4:
+        report.errors.append(f"地标数量不足: {report.landmark_count}/4")
+
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for item in landmark_map:
+        if not isinstance(item, dict):
+            report.errors.append("landmark_map 含非对象条目")
+            continue
+        landmark_id = item.get("id")
+        node_id = item.get("node_id")
+        if not isinstance(landmark_id, str) or not landmark_id:
+            report.errors.append("landmark_map 条目缺少 id")
+            continue
+        by_id[landmark_id] = item
+        if not isinstance(node_id, str) or node_id not in nodes:
+            report.errors.append(f"地标 {landmark_id} 指向不存在节点: {node_id}")
+
+    for landmark_id, item in by_id.items():
+        connections = item.get("connections") or []
+        if not connections:
+            report.errors.append(f"地标 {landmark_id} 缺少 connections 邻边")
+            continue
+        for target in connections:
+            if target not in by_id:
+                report.errors.append(f"地标 {landmark_id} 连接不存在地标: {target}")
+
+
+def _check_tools(
+    payload: Dict[str, Any],
+    nodes: Dict[str, Dict[str, Any]],
+    report: SandboxReport,
+) -> None:
+    """检查工具节点和 stay 自循环。"""
+    tool_nodes = {node_id for node_id, node in nodes.items() if node.get("_is_tool")}
+    tools_meta = payload.get("tools") or {}
+    if isinstance(tools_meta, dict):
+        for tool_id, meta in tools_meta.items():
+            if not isinstance(meta, dict):
+                report.errors.append(f"tools.{tool_id} 必须是对象")
+                continue
+            node_id = meta.get("node_id")
+            if isinstance(node_id, str) and node_id in nodes:
+                tool_nodes.add(node_id)
+            else:
+                report.errors.append(f"tools.{tool_id}.node_id 指向不存在节点: {node_id}")
+
+    report.tool_nodes = sorted(tool_nodes)
+    if len(report.tool_nodes) < 2:
+        report.errors.append(f"工具节点数量不足: {len(report.tool_nodes)}/2")
+
+    stay_loop_nodes: Set[str] = set()
+    for node_id in tool_nodes:
+        node = nodes.get(node_id) or {}
+        for choice in choices_of(node):
+            effects = choice.get("effects") or {}
+            if not isinstance(effects, dict) or not effects.get("stay"):
+                continue
+            if node_id in choice_targets(choice):
+                stay_loop_nodes.add(node_id)
+    report.stay_loop_nodes = sorted(stay_loop_nodes)
+    if not report.stay_loop_nodes:
+        report.errors.append("缺少 effects.stay=true 且 next 指回自身的工具自循环")
+
+
+def _check_reaction_variants(
+    nodes: Dict[str, Dict[str, Any]],
+    report: SandboxReport,
+) -> None:
+    """检查至少一个 variant 使用反应 clause。"""
+    reaction_nodes: Set[str] = set()
+    for node_id, node in nodes.items():
+        for variant in _iter_variants(node):
+            cond = variant.get("if") or {}
+            if _contains_reaction_clause(cond):
+                reaction_nodes.add(node_id)
+    report.reaction_variant_nodes = sorted(reaction_nodes)
+    if not report.reaction_variant_nodes:
+        report.errors.append("缺少使用 deduction/foreshadow/theme/ending_seen 的反应式 variant")
+
+
+def _iter_variants(node: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    """遍历 narrative_variants 和 choice.next_variants。"""
+    for variant in node.get("narrative_variants") or []:
+        if isinstance(variant, dict):
+            yield variant
+    for choice in choices_of(node):
+        for variant in choice.get("next_variants") or []:
+            if isinstance(variant, dict):
+                yield variant
+
+
+def _contains_reaction_clause(clause: Any) -> bool:
+    """递归判断条件里是否含 ADR-010 反应 clause。"""
+    if not isinstance(clause, dict):
+        return False
+    if any(key in clause for key in REACTION_KEYS):
+        return True
+    for key in ("all_of", "any_of"):
+        items = clause.get(key) or []
+        if isinstance(items, list) and any(_contains_reaction_clause(item) for item in items):
+            return True
+    return _contains_reaction_clause(clause.get("not"))
+
+
+def _check_presentation(nodes: Dict[str, Dict[str, Any]], report: SandboxReport) -> None:
+    """统计 presentation 覆盖率。
+
+    presentation 红线由 audit_playability 负责,这里仅保留计数,避免工具职责打架。
+    """
+    report.presentation_nodes = sum(
+        1 for node in nodes.values() if isinstance(node.get("presentation"), dict)
+    )
+
+
+def render_report(report: SandboxReport) -> str:
+    """渲染人类可读报告。"""
+    lines = [
+        "════════ ADR-010 沙盒骨架审计 ════════",
+        f"节点: {report.node_count}",
+        f"picker hub: {len(report.picker_nodes)}",
+        f"地标: {report.landmark_count}",
+        f"工具节点: {len(report.tool_nodes)}",
+        f"stay 自循环工具: {len(report.stay_loop_nodes)}",
+        f"反应 variant 节点: {len(report.reaction_variant_nodes)}",
+        f"演出节点: {report.presentation_nodes}/{report.node_count}",
+        "",
+    ]
+    if report.errors:
+        lines.append("错误:")
+        lines.extend(f"  ❌ {item}" for item in report.errors)
+    if report.warnings:
+        if report.errors:
+            lines.append("")
+        lines.append("警告:")
+        lines.extend(f"  ⚠️  {item}" for item in report.warnings)
+    if not report.errors and not report.warnings:
+        lines.append("无错误 / 无警告")
+    lines.append("")
+    lines.append("结果: " + ("通过" if report.ok else "失败"))
+    return "\n".join(lines)
+
+
+def main(argv: List[str] | None = None) -> int:
+    """CLI 入口。"""
+    parser = argparse.ArgumentParser(description="审计 GameTree v1 是否符合 ADR-010 沙盒骨架")
+    parser.add_argument("tree_json", help="故事树 JSON 路径")
+    parser.add_argument("--json", action="store_true", help="输出 JSON 报告")
+    args = parser.parse_args(argv)
+
+    path = Path(args.tree_json)
+    report = analyze_sandbox(load_payload(path), tree_path=str(path))
+    if args.json:
+        print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        print(render_report(report))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/run_all_tests.py
+++ b/tools/run_all_tests.py
@@ -118,6 +118,7 @@ def main():
             [
                 "tests/test_view_tree_progress.py",
                 "tests/test_audit_playability.py",
+                "tests/test_audit_sandbox.py",
                 "tests/test_npc_accountability_pass8.py",
             ],
         ),


### PR DESCRIPTION
Closes #23

## 变更
- 新增 tools/audit_sandbox.py，按 ADR-010 检查 picker hub / landmark connections / tool / stay 自循环 / 反应式 variant。
- tools/audit_all.sh 接入 audit_sandbox，全套审计从 6 项扩展到 7 项。
- GameTreePlan.to_minimal_tree() 补齐最小结局、静态 picker 选项、地标实际跳转、工具退出、反应契约 resolver。
- 新增 tests/test_audit_sandbox.py，并扩展 tests/test_gametree_plan.py。
- 更新 TASK_V4_GAMETREE_ALIGNMENT.md 与团队评审留痕。

## 验证
- .venv/bin/python -m pytest tests/test_audit_sandbox.py tests/test_gametree_plan.py -q
- python3 tools/audit_sandbox.py stories/hangzhou_yebanbaoan/tree.json
- bash tools/audit_all.sh
- .venv/bin/python tools/run_all_tests.py

## 约束
- 不修改 DB schema。
- 不替换正式杭州手写树。
- audit_sandbox 只守沙盒骨架，不重复 playability / reactions / variants 的职责。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sandbox audit capability to validate game tree structure compliance with minimum skeleton requirements (at least 4 landmarks, 2+ tools, navigation edges).
  * Enhanced minimal tree generation with improved navigation choices between landmark locations and return-to-map options in tool nodes.

* **Tests**
  * New test suite for sandbox audit validation, including real game tree integration tests.

* **Documentation**
  * Added audit review documentation and completion status for v4 sandbox skeleton implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->