### PR TITLE
Step 2: 重写README主轴+新增SCRIPTING剧本编写指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,739 +1,139 @@
-# Ghost Story Factory
+# 杭州夜班保安
 
-[![Version](https://img.shields.io/badge/version-v0.1.0-blue.svg)](https://github.com/yehan-s/ghost-story-factory/releases/tag/v0.1.0)
-[![Python](https://img.shields.io/badge/python-3.12+-green.svg)](https://www.python.org/downloads/)
+[![Version](https://img.shields.io/badge/version-v2.0.0-blue.svg)](https://github.com/yehan-s/ghost-story-factory/releases)
+[![Python](https://img.shields.io/badge/python-3.10+-green.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE)
 
-**一个专业的灵异故事生成工厂** - 基于 LLMClient 和专业 templates 模板，自动生成完整的、高质量的灵异故事。
+> 一个文字冒险游戏。
+> 你扮演夜班保安 G-273,
+> 在一座有些不对劲的杭州物资仓库里,
+> 用一晚上拼出 8 张照片背后的真相。
 
-> 🎮 **不只是故事生成器，更是交互式游戏开发工具**
-> 从世界观设计到 AI 导演系统，从静态故事到动态游戏，一站式解决方案。
-
-## 📦 v0.1.0 新特性 (2025-10-25)
-
-**核心游戏引擎**
-- ✅ 交互式游戏引擎（Dynamic Mode + Pregenerated Mode）
-- ✅ CLI UI 美化（rich 库，交互式菜单）
-- ✅ 多结局系统（补完/旁观/迷失）
-
-**架构重构**
-- ✅ ADR-004/006: LLMClient 架构（替代 CrewAI）
-- ✅ ADR-005: LangGraph 编排层（JSON 稳定性 100%）
-- ✅ 节点级遥测与诊断系统
-
-**工程优化**
-- ✅ 并行生成能力（智能动态队列）
-- ✅ 集中式日志系统（时间戳文件 + 堆栈跟踪）
-- ✅ 单元测试覆盖率 >80%
-
-📖 完整变更日志：[CHANGELOG.md](CHANGELOG.md)
+终端里跑的全屏 TUI,沙盒拓扑、跨周目人格惯性、可反复访问的 NPC 对话变体。
+**12 种结局,162 个节点**,主角线 5 个主要 ending + 4 个 BAD/NEUTRAL ending +
+4 个 1985 年前传线 ending。
 
 ---
 
-## 📌 项目简介
+## 玩(选一种)
 
-Ghost Story Factory 是一个基于 **Top-Down 叙事设计** 的专业故事生成工具，采用 **世界观 → 角色 → 游戏设计 → 故事** 的分层架构，确保生成内容的一致性和可玩性。
-
-**适用场景：**
-- 📖 内容创作者：快速生成高质量灵异故事文案
-- 🎮 游戏开发者：获得完整的游戏设计文档（GDD + 世界观）
-- 🎬 UP主/播客：获得可直接配音的故事脚本
-- 🔬 叙事研究者：学习专业的故事设计流程
-
----
-
-## 📚 文档索引
-
-### 快速上手 ⚡
-
-| 文档 | 说明 |
-|------|------|
-| [QUICK_START.md](QUICK_START.md) | **5分钟快速开始** ⭐ 推荐 |
-| [docs/COMMANDS.md](docs/COMMANDS.md) | **命令速查手册** 📖 所有命令详解 |
-
-### 核心功能
-
-| 文档 | 说明 |
-|------|------|
-| [docs/PREGENERATION_DESIGN.md](docs/PREGENERATION_DESIGN.md) | 静态对话预生成系统设计 |
-| [docs/CHECKPOINT_RESUME.md](docs/CHECKPOINT_RESUME.md) | 断点续传功能说明 ⚡ |
-| [docs/CHECKPOINT_FEATURE_COMPLETE.md](docs/CHECKPOINT_FEATURE_COMPLETE.md) | 断点续传实现报告 |
-
-### 开发文档
-
-| 文档 | 说明 |
-|------|------|
-| [docs/OPTIMIZATION_SUMMARY.md](docs/OPTIMIZATION_SUMMARY.md) | 性能优化总结 |
-| [PROJECT_STATUS.md](PROJECT_STATUS.md) | 项目状态 |
-| [ENV_EXAMPLE.md](ENV_EXAMPLE.md) | 环境变量配置示例 |
-| [docs/specs/SPEC_TODO.md](docs/specs/SPEC_TODO.md) | 开发规格与待办 |
-
----
-
-## 🌟 核心特性
-
-- ✅ **自动化生成**：输入城市名，自动生成完整故事（≥5000字）
-- ✅ **专业templates**：基于35个专业设计模式（[templates文件夹](./templates/)）
-- ✅ **分层架构**：阶段1（世界书1.0）→ 阶段2（主角分析）→ 阶段3（GDD+故事）→ 阶段4（交互层）
-- ✅ **选项交互式设计**：支持生成游戏化的选择点系统
-- ✅ **共鸣度系统**：动态的玩家-世界互动机制
-- ✅ **后果树（Consequence Tree）**：多分支结局设计
-- ✅ **AI做体力活，人类做创意活**
-
----
-
-## 🎯 核心优势
-
-### 1. **专业的叙事设计流程**
-不是简单的"输入提示词→输出故事"，而是遵循专业游戏叙事设计流程：
-```
-原始素材 → Lore v1（世界观基础） → 主角分析 → Lore v2（系统增强）
-→ GDD（AI导演任务简报） → 主线故事（≥5000字）
-```
-
-### 2. **可复用的中间产物**
-每个阶段的输出都是独立可用的：
-- **Lore v1/v2**：可用于世界观设定
-- **主角分析**：可用于角色设计
-- **GDD**：可直接用于游戏开发
-- **主线故事**：可直接配音/发布
-
-### 3. **游戏化设计支持**
-不仅生成静态故事，还支持：
-- 🎮 选项式交互设计
-- 📊 共鸣度系统（玩家状态追踪）
-- 🌳 后果树（多分支结局）
-- 🤖 AI导演系统（动态响应）
-
----
-
-## 🏗️ 架构概览
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    Ghost Story Factory                      │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  Stage 1: 候选与结构                                         │
-│  ├─ set-city      → 城市候选列表 (candidates.json)          │
-│  └─ get-struct    → 故事结构框架 (struct.json)              │
-│                                                             │
-│  Stage 2: 世界观基础                                         │
-│  ├─ get-lore         → Lore v1 (lore.json)                 │
-│  └─ gen-protagonist  → 主角设计 (protagonist.md)           │
-│                                                             │
-│  Stage 3: 系统增强                                           │
-│  ├─ gen-lore-v2   → Lore v2 (lore_v2.md) [含游戏系统]       │
-│  └─ gen-gdd       → GDD (GDD.md) [AI导演任务简报]          │
-│                                                             │
-│  Stage 4: 故事生成                                           │
-│  ├─ gen-main-thread → 主线故事 (main_thread.md)            │
-│  └─ gen-branch      → 分支故事 (branch_X.md)               │
-│                                                             │
-│  ⚡ 自动流水线                                                │
-│  └─ gen-complete  → 一键完成 Stage 2-4                      │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**详细架构**：查看 [ARCHITECTURE.md](./ARCHITECTURE.md)
-
-## ⚡ 快速开始（推荐）
-
-### ⭐ 新推荐：自动流水线（3步完成！）
+### A. 从源码跑(推荐,最稳)
 
 ```bash
-# 1. 获取候选故事
-set-city --city "杭州"
-
-# 2. 选择故事框架
-get-struct --city "杭州" --index 1
-
-# 3. 一键生成所有内容（自动执行 5 个步骤！）
-gen-complete --city "杭州" --index 1
-```
-
-**🎯 自动完成：** Lore v1 → 主角设计 → Lore v2 → GDD → 主线故事（≥5000字）
-
----
-
-### 游戏运行模式（新增）
-
-项目现在支持两种运行模式：
-
-- ✅ **动态模式（LLM 实时生成）**：完整 AI 驱动，实时生成所有对话与响应
-- ✅ **预生成模式（零等待）**：先离线生成完整对话树，游玩时直接读取数据库/文件
-
-#### A) 动态模式（完整体验）
-
-```bash
-# 需要 KIMI_API_KEY 或 OPENAI_API_KEY
-python play_game_full.py
-```
-
-特性：
-- LLM 实时生成，剧情自适应
-- 完整的 S1-S6 主线，15-30 分钟
-- 需要网络与 API Key
-
-#### B) 预生成模式（零等待）✨ **推荐**
-
-```bash
-# 🎮 启动游戏（主菜单）
-./start_pregenerated_game.sh
-
-# 或直接运行
-python play_game_pregenerated.py
-```
-
-**特性：**
-- ✅ **零等待**：先生成，再游玩；游玩阶段 0 等待
-- ✅ **断点续传**：生成过程可随时中断，自动恢复 ⚡
-- ✅ **数据库存储**：完整对话树存储在 SQLite 数据库
-- ✅ **高质量模型**：生成时可使用更强的模型（kimi-k2-0905-preview）
-- ✅ **适合发行**：无需 API Key 即可游玩已生成的故事
-
-**主菜单功能：**
-1. **选择故事**：从已生成的故事库中选择并开始游玩
-2. **生成故事**：输入城市名，AI 自动生成完整故事（2-4小时，支持断点续传）
-
----
-
-### 游戏模式详细对比
-
-#### 性能对比表
-
-| 指标 | 预生成模式 | 动态模式 |
-|-----|-----------|---------|
-| **响应时间** | **<0.001s** | 3-8s |
-| **启动时间** | <1s | ~5s |
-| **完整游戏（30轮）** | **<0.1s** | 90-240s |
-| **网络依赖** | 无 | 强依赖（Kimi API）|
-| **内存占用** | 低（仅对话树）| 高（GDD + Lore + LLM）|
-| **成本** | 无（生成后）| 每轮 ~$0.01 |
-| **适用场景** | 正式发布 | 快速迭代测试 |
-
-#### 关键指标
-
-- ⚡ **零延迟体验**: 预生成模式单次查询 <1ms，完全消除等待
-- 🚀 **性能提升**: 相比动态模式提升 **900x ~ 2400x**
-- 💾 **离线可用**: 无需 API Key，完全本地运行
-- 📦 **存储优化**: 1000 节点对话树 ~2MB（gzip 压缩）
-
-#### 推荐使用场景
-
-**预生成模式（推荐）**:
-- ✅ 正式游戏发布
-- ✅ 移动端/低配设备
-- ✅ 离线游戏体验
-- ✅ 大规模玩家测试
-- ✅ 无网络环境
-
-**动态模式**:
-- ✅ 快速迭代测试
-- ✅ 内容创作阶段
-- ✅ 动态故事实验
-- ✅ 小规模内部测试
-
-**技术细节**: 查看 [API 文档](docs/api/pregenerated-mode.md)
-
-**快速开始：**
-```bash
-# 1. 启动游戏
-./start_pregenerated_game.sh
-
-# 2. 选择"生成故事"（首次使用）
-选择：2
-
-# 3. 输入城市名
-城市：上海
-
-# 4. 选择故事简介
-（从 AI 生成的 3 个简介中选择）
-
-# 5. 等待生成完成（2-4小时，可随时中断）
-⚠️  生成过程预计 2-4 小时
-✅ 支持断点续传：如果中断，下次输入相同城市名即可恢复
-
-# 6. 生成完成后，选择"选择故事"即可开始游玩
-选择：1
-```
-
-**断点续传使用：**
-```bash
-# 查看未完成的生成任务
-./check_progress.sh
-
-# 如果中断，重新运行时输入相同城市名即可恢复
-./start_pregenerated_game.sh
-选择：2
-城市：上海  ← 必须与之前相同
-✅ 自动从断点继续
-```
-
-> 详细文档：
-> - 《静态对话预生成系统 - 设计文档》：`docs/PREGENERATION_DESIGN.md`
-> - 《断点续传功能说明》：`docs/CHECKPOINT_RESUME.md`
-> - 《命令速查手册》：`docs/COMMANDS.md`
-
----
-
-### 一键生成完整故事（备选方案）
-
-```bash
-# 1. 安装依赖
+git clone https://github.com/yehan-s/ghost-story-factory
+cd ghost-story-factory
 uv venv && source .venv/bin/activate
 uv pip install -e .
-
-# 2. 配置环境变量（创建 .env 文件）
-# KIMI_API_KEY=your_key_here  # 或 OPENAI_API_KEY
-
-# 3. 生成故事（自动执行完整流程，包含主线 + 支线）
-python generate_full_story.py --city 武汉
-
-# 只生成主线，不生成支线
-python generate_full_story.py --city 武汉 --no-branches
-
-# 或使用shell脚本
-chmod +x generate_full_story.sh
-./generate_full_story.sh 武汉
+python play_tui.py
 ```
 
-**输出目录：** `deliverables/程序-武汉/`
-
-**生成文件：**
-- ✅ `武汉_lore_v1.md` - 世界书1.0（高保真地基）
-- ✅ `武汉_protagonist.md` - 角色分析
-- ✅ `武汉_lore_v2.md` - 世界书2.0（游戏化规则）🎮
-- ✅ `武汉_gdd.md` - AI导演任务简报（主线）🎮
-- ✅ `武汉_story.md` - **主线故事（⭐最终产物）**
-- 🌿 `武汉_branch_1_gdd.md` - 支线1 GDD（店主线）🎮
-- 🌿 `武汉_branch_1_story.md` - 支线1故事文案 ⭐
-- 🌿 `武汉_branch_2_gdd.md` - 支线2 GDD（顾客线）🎮
-- 🌿 `武汉_branch_2_story.md` - 支线2故事文案 ⭐
-- ✅ `README.md` - 说明文档
-
-**🎮 = 游戏引擎所需文件 | 🌿 = 支线内容（可选）**
-
----
-
-### 运行交互式游戏（动态模式）
-
-生成故事后，可以运行交互式游戏引擎：
+### B. `pipx` 安装(纯命令使用)
 
 ```bash
-# 启动游戏（基于生成的GDD和Lore v2）
-python game_engine.py \
-    --city 武汉 \
-    --gdd deliverables/程序-武汉/武汉_gdd.md \
-    --lore deliverables/程序-武汉/武汉_lore_v2.md
+pipx install git+https://github.com/yehan-s/ghost-story-factory
+ghost-story-tui
 ```
 
-**游戏特性：**
-- 🎯 选项式交互（A/B/C/D）
-- 📝 AI实时生成响应
-- 🔄 动态状态管理
-- 🎮 多结局系统
-
-**详细说明：** 查看 [GAME_ENGINE.md](./GAME_ENGINE.md)
+> **当前已知限制**:剧本路径目前从 repo 根读取,装包模式下需要 `cd` 到本仓库目录跑。
+> 单文件 release(零环境依赖)在 Step 3 路线图上。
 
 ---
 
-### 运行交互式游戏（预生成模式）
+## 控制
+
+**菜单**:↑↓ 移动 / Enter 选择 / b 或 Esc 返回 / q 退出
+
+**游戏**:↑↓ 选项 / Enter 确认 / 1–9 快选 / s 状态面板 / q 退出
+
+---
+
+## 剧情结构
+
+| 维度 | 数量 |
+|---|---|
+| 节点总数 | 162 |
+| 主线主结局 | 5(E_TRUE / E_TRUTH / E_BROADCAST / E_DATA / E_HIDDEN) |
+| 中性 / BAD 结局 | 3(E_NEUTRAL / E_BAD_1987 / E_BAD_DROWN) |
+| 1985 前传线结局 | 4(RELEASE / EXPOSED / GRIEVANCE / REGRET) |
+| 可反复访问 NPC | 7 |
+| 沙盒地标 | 6(picker 中枢 + 横向 connections) |
+
+**跨周目人格惯性**:上一次通关结局会影响下一次开场的"残影"——
+通关 E_TRUE,开局你会**下意识把手伸进衣袋**找一封不存在的信;
+通关 E_DATA,对讲机里前任会**先报字段名问你确认 schema**。
+
+**反应式 NPC**:看过某条伏笔后,下次访问对话会**自动切换变体**,
+不是单链回放。
+
+---
+
+## 项目结构
+
+```
+src/ghost_story_factory/
+├── v5/         玩家状态 + 派生量(meets / effects / behavior_profile)
+├── v7/         全屏 TUI 播放器(textual)
+└── runtime/    GameTree 契约(RequirementEvaluator / EffectApplier / EndingResolver)
+
+stories/hangzhou_yebanbaoan/
+├── tree.json                # 合并产物,真正被引擎读
+└── _fragment_v7_*.json      # 9 个手写片段,merge_fragments.py 编译成 tree.json
+
+tools/
+├── merge_fragments.py       # 编译剧本
+├── audit_*.py(13 项)        # 剧本质检
+└── run_all_tests.py         # 跑测试套件
+
+docs/
+├── architecture/            # ADR-007 ~ ADR-011(运行时契约)
+└── SCRIPTING.md             # 想自己写剧本?看这个
+```
+
+---
+
+## 想自己写剧本?
+
+看 [docs/SCRIPTING.md](docs/SCRIPTING.md)。
+
+核心套路:
+- **沙盒不是死剧本**:picker hub + landmark connections + tool 节点 + 反应 variants
+- **0 新真相源**:`endings_seen` / `foreshadows_seen` / `deductions_resolved` 是单一真相,不许加镜像 flag
+- **跨周目联动**:`ending_seen.ending_id`(曾经)+ `ending_seen.last`(最近)
+
+ADR 索引在 [docs/INDEX.md](docs/INDEX.md)。
+
+---
+
+## 历史代码 / LLM 生成流水线
+
+本项目早期(v0.x–v1.x)是 LLM 自动生成 VN 剧本的工具,
+基于 CrewAI + LangGraph + LLMClient 流水线。
+
+**v2.0.0 起转型为 VN 沙盒播放器**,
+LLM 流水线整套代码冻结在 [`legacy/llm-pipeline`](https://github.com/yehan-s/ghost-story-factory/tree/legacy/llm-pipeline) 分支,永不删除。
+
+如需复活:`git checkout legacy/llm-pipeline`,见该分支的 `LEGACY.md`。
+
+---
+
+## 开发
 
 ```bash
-# 预生成模式（主菜单：选择故事 或 触发生成）
-./start_pregenerated_game.sh
+# 编辑剧本片段
+$EDITOR stories/hangzhou_yebanbaoan/_fragment_v7_shared.json
 
-# 直接运行入口
-python play_game_pregenerated.py
+# 编译
+python tools/merge_fragments.py
+
+# 跑 13 项审计(沙盒拓扑 / 反应契约 / 跨周目联动 / 人格惯性...)
+bash tools/audit_all.sh
+
+# 跑测试套件
+python tools/run_all_tests.py
 ```
 
-说明：
-- 该模式不需要在游玩时调用 LLM；生成阶段可使用更高质量模型
-- 预生成流程的 CLI 设计详见 `docs/PREGENERATION_DESIGN.md`
-
 ---
 
-## 📖 详细安装与运行
+## License
 
-建议使用 `uv`（或 `pip`）。项目已提供 `pyproject.toml` 与脚本入口。
-
-### 方式A：使用新生成器（推荐）🎯
-
-```bash
-# 完整流程，基于templates模板
-python generate_full_story.py --city 广州 --output deliverables/程序-广州/
-```
-
-**优点：**
-- ✅ 自动执行阶段1→2→3的完整流程
-- ✅ 使用templates文件夹中的专业提示词
-- ✅ 生成所有中间产物（lore、protagonist、GDD等）
-- ✅ 最终输出完整故事
-
----
-
-### 方式B：使用旧命令行工具（兼容模式）
-
-#### 本地开发
-
-```bash
-# 1) 创建并激活虚拟环境
-uv venv
-source .venv/bin/activate
-
-# 2) 安装到可编辑模式
-uv pip install -e .
-
-# 3) 配置环境变量（创建 .env）
-# 必需：OPENAI_API_KEY=...
-# 若使用 Google 搜索：
-#   GOOGLE_API_KEY=...
-#   GOOGLE_CSE_ID=...
-
-# 4) 运行（两种方式，择一）
-# A) 可编辑安装后的直接运行
-set-city --city "广州"      # 列出候选（名称+简介），保存 广州_candidates.json
-get-struct --city "广州"   # 选定候选并生成结构化框架，保存 广州_struct.json
-get-story --city "广州"    # 若存在 广州_struct.json 则按框架写作，否则走全流程
-
-# B) 本地临时环境运行（不污染环境）
-uvx --from . set-city --city "广州"
-uvx --from . get-struct --city "广州"
-uvx --from . get-story --city "广州"
-
-# 自定义输出文件名（例如导出到 deliverables 目录）
-uvx --from . get-story --city "广州" --out "deliverables/程序-广州/广州_story.md"
-```
-
-### 作为一次性工具运行（发布到 PyPI 后）
-
-```bash
-# 使用 uvx（推荐写法）
-uvx --from ghost-story-factory set-city --city "东莞"
-uvx --from ghost-story-factory get-struct --city "东莞"
-uvx --from ghost-story-factory get-story --city "东莞"
-
-# 锁定版本（可选，保证可重复）
-uvx --from ghost-story-factory==1.0.0 get-story --city "东莞"
-
-# 或使用 pipx（等价）
-pipx run --spec ghost-story-factory get-story --city "东莞"
-```
-
-## 依赖
-
-- crewai>=0.30.0
-- langchain-community
-- langchain-google-community
-- langchain-openai
-- python-dotenv
-
-## 工作流说明
-
-顺序执行三步：
-1) 搜索素材（GoogleSearchRun）
-2) 提炼故事结构（JSON 框架）
-3) 扩写成 Markdown 故事
-
-产出文件：`[城市名]_story.md`
-
-## 免责声明
-
-- 需自行提供并合法使用 API Key（OpenAI/Google 等）。
-- 网络检索结果可能包含不准确或有偏差的信息，使用前请审阅与二次创作。
-
-## LLM 配置（OpenAI 或 Kimi）
-
-本工具支持通过环境变量选择不同的兼容提供商（优先使用 Kimi，再回退到 OpenAI）。同时兼容 MoonLens 中使用的 MOONSHOT_* 命名。
-
-- 使用 Kimi（Moonshot）：
-  - `KIMI_API_KEY=...`
-  - 可选：`KIMI_API_BASE=https://api.moonshot.cn/v1`（默认已是该值）
-  - 可选：`KIMI_MODEL=kimi-k2-0905-preview`
-  - 兼容：`MOONSHOT_API_KEY`、`MOONSHOT_API_URL`、`MOONSHOT_MODEL`
-
-- 使用 OpenAI（或兼容代理）：
-  - `OPENAI_API_KEY=...`
-  - 可选：`OPENAI_BASE_URL=...`（或 `OPENAI_API_BASE=...`）
-  - 可选：`OPENAI_MODEL=gpt-4o`
-
-优先级：`KIMI_*` > `OPENAI_*`。未配置任一密钥将无法运行。
-
-## 自定义 Prompt 文件
-
-本项目支持用仓库根目录下的 Markdown 提示词文件，精确控制三条命令的行为与风格：
-
-- set-city.md
-  - 作用：生成城市候选列表
-  - 变量：`{city}`
-  - 输出：严格的 JSON 数组（每项仅含 `title`,`blurb`,`source`）
-  - 约束：只返回一个 ```json 代码块；强制 ASCII 双引号，不得使用中文引号/书名号
-
-- get-struct.md
-  - 作用：从原始素材中提炼结构化框架
-  - 变量：`{raw_text_from_agent_a}`（由命令内部先让研究员汇编长文素材后注入）
-  - 输出：仅一个 JSON 代码块；必须包含键：
-    - `title` (string)
-    - `city` (string)
-    - `location_name` (string)
-    - `core_legend` (string)
-    - `key_elements` (string[])
-    - `potential_roles` (string[])
-
-- get-story.md
-  - 作用：将结构化 JSON 扩写为 UP 主讲述风格的 Markdown 文案
-  - 变量：`{json_skeleton_from_agent_b}`（即 `*_struct.json` 的完整 JSON 字符串）
-  - 输出：仅 Markdown 文案，≥1500 字，强氛围、第二人称倾向、可直接配音
-
-放置/修改以上文件后，命令会优先读取这些 md；若缺失，则使用内置默认提示词。
-
-## 顶层设计（Top-Down Design）工作流
-
-推荐以"世界观 → 角色拍点 → **完整故事**"的顺序产出，保证一致性与可复用。
-
-### ⚡ 方式 A：一键生成（推荐）
-
-```bash
-# 自动完成 3 步：lore → role → story
-./generate_full_story.sh 武汉 夜跑者
-
-# 自定义输出路径
-./generate_full_story.sh 广州 保安 deliverables/广州_story.md
-```
-
-**⚠️ 重要**：这个脚本会自动生成 **完整的 Markdown 故事**，而不仅仅是 JSON！
-
-### 📋 方式 B：手动分步执行
-
-**第 1 步**：生成世界观圣经（lore）
-
-```bash
-uvx --from . get-lore --city "广州" --title "荔湾"
-# 输出：广州_lore.json
-```
-
-**第 2 步**：生成角色剧情拍点（beats）
-
-```bash
-uvx --from . gen-role --city "广州" --role "保安" --pov "第二人称"
-# 输出：广州_role_保安.json
-```
-
-**第 3 步**：生成完整故事 ← **必须执行，否则只有 JSON！**
-
-```bash
-uvx --from . get-story --city "广州" --role "保安" --out "deliverables/广州_story.md"
-# 输出：广州_story.md ✅ 这才是完整的故事！
-```
-
-**第 4 步**：一致性校验（可选）
-
-```bash
-uvx --from . validate-role --city "广州" --role "保安"
-```
-
-### 📁 产出文件说明
-
-| 文件类型 | 示例 | 说明 |
-|---------|------|------|
-| `*_lore.json` | `武汉_lore.json` | 世界观圣经（中间文件） |
-| `*_role_*.json` | `武汉_role_夜跑者.json` | 角色剧情拍点（中间文件） |
-| `*_story.md` | `武汉_story.md` | **✅ 完整故事（最终产物）** |
-
-**💡 提示**：JSON 文件是中间产物，用于保证一致性。最终的故事在 `.md` 文件中！
-
----
-
-所有新增命令均不破坏现有 set-city / get-struct / get-story 契约，仅作为增强。
-
----
-
-## 📊 示例输出
-
-### 杭州 - 北高峰午夜缆车空厢
-
-**生成的文件：**
-```
-杭州_candidates.json      # 6个候选故事
-杭州_struct.json          # 故事结构框架
-杭州_lore.json            # 世界观基础（JSON）
-杭州_protagonist.md       # 主角分析报告
-杭州_lore_v2.md           # 世界观系统增强版（含共鸣度）
-杭州_GDD.md               # AI导演任务简报
-杭州_main_thread.md       # 完整主线故事（5000+字）
-```
-
-**故事特色：**
-- 🎭 低频象征物："000号车厢"、"00:44时间"
-- 🎬 多感官细节：机油味、钢缆震颤、冰露触感
-- 📖 完整叙事弧：建置→异象→深挖→反转→高潮→余波
-- 🎯 B站UP主风格：第二人称代入、强节奏停顿、可配音
-
-**查看完整示例：** [杭州_story.md](./杭州_story.md)
-
----
-
-## 🤝 贡献指南
-
-欢迎贡献！您可以：
-
-1. **添加新的templates模板**
-   - 在 `templates/` 文件夹中添加新的 `.design.md`, `.example.md`, `.prompt.md`
-   - 遵循三文件模式（设计-示例-提示词）
-
-2. **改进提示词**
-   - 优化现有的 prompt 模板
-   - 提高生成质量
-
-3. **报告问题**
-   - 在 [Issues](https://github.com/your-username/ghost-story-factory/issues) 提交bug报告
-   - 提供详细的复现步骤
-
-4. **提交新功能**
-   - Fork 本仓库
-   - 创建功能分支
-   - 提交 Pull Request
-
-**代码风格：**
-- 遵循 PEP 8
-- 使用有意义的变量名
-- 添加必要的注释和文档字符串
-
----
-
-## ❓ 常见问题（FAQ）
-
-### 1. 为什么需要先运行 `set-city` 和 `get-struct`？
-
-这是为了让用户有**选择权**。`set-city` 生成多个候选故事，用户可以选择最感兴趣的一个，而不是由AI随机决定。
-
-### 2. `gen-complete` 和 `generate_full_story.py` 有什么区别？
-
-- **`gen-complete`**：命令行工具，适合分步调试和精细控制
-- **`generate_full_story.py`**：Python脚本，适合一键自动化，会生成到指定输出目录
-
-### 3. 生成的故事质量如何保证？
-
-通过**多层验证**：
-1. Lore v1 提供世界观一致性
-2. 主角分析确保角色合理性
-3. Lore v2 添加游戏系统约束
-4. GDD 提供叙事结构指导
-5. templates模板提供质量标准
-
-### 4. 可以用于商业项目吗？
-
-**可以**，但请注意：
-- 本项目代码遵循 MIT 许可证
-- AI生成的内容版权归使用者
-- 需自行确保API使用合规（OpenAI/Kimi ToS）
-
-### 5. 支持哪些LLM？
-
-目前支持：
-- ✅ Kimi (Moonshot) - 推荐，长文本支持好
-- ✅ OpenAI (GPT-4o/GPT-4) - 备选
-- ✅ 任何 OpenAI 兼容 API
-
-### 6. 为什么有些命令超时？
-
-**常见原因：**
-- Kimi API 限流（504 Gateway Timeout）
-- 生成内容过长（使用 `gen-complete` 分步生成）
-
-**解决方案：**
-1. 使用 `gen-complete --city "城市名" --index 1`（会自动跳过已生成文件）
-2. 检查 `.env` 中的 API Key 是否有效
-3. 尝试切换到 OpenAI API
-
-### 7. 如何自定义故事风格？
-
-修改 `templates/` 文件夹中的 `.prompt.md` 文件，或在项目根目录创建自定义 prompt：
-- `set-city.md`
-- `get-struct.md`
-- `get-story.md`
-
----
-
-## 🛠️ 技术栈
-
-| 组件 | 技术 | 用途 |
-|------|------|------|
-| **AI 框架** | [CrewAI](https://github.com/joaomdmoura/crewAI) | 多Agent协作 |
-| **LLM** | Kimi/OpenAI | 内容生成 |
-| **包管理** | [uv](https://github.com/astral-sh/uv) | 快速依赖管理 |
-| **环境配置** | python-dotenv | 环境变量管理 |
-| **语言链** | LangChain | LLM工具链 |
-
----
-
-## 📜 许可证
-
-本项目采用 **MIT License** 开源。
-
-详见 [LICENSE](./LICENSE) 文件。
-
----
-
-## 🙏 致谢
-
-- **设计灵感**：Linus Torvalds 的"Good Taste"设计哲学
-- **叙事理论**：《Save the Cat!》、《The Anatomy of Story》
-- **技术支持**：CrewAI 团队、LangChain 社区
-- **templates贡献者**：感谢所有提供专业设计模式的贡献者
-
----
-
-## 📈 版本历史
-
-### v3.1 (2025-10-24) - 当前版本 🎯
-
-- ✨ 添加自动流水线命令 `gen-complete`
-- ✨ 新增 6 个核心命令（gen-protagonist, gen-lore-v2, gen-gdd等）
-- 📚 完善文档体系（WORKFLOW.md, QUICK_REFERENCE.md等）
-- 🎮 添加交互式游戏引擎（game_engine.py）
-- 📦 完整的templates模板库（35个文件）
-
-### v3.0 (2025-10-23)
-
-- ✨ 添加 Stage 4 交互层设计
-- ✨ 选项交互式游戏支持
-- 📚 templates库初版
-
-### v2.0
-
-- ✨ Top-Down 设计工作流
-- ✨ Lore + Role Beats 系统
-
-### v1.0
-
-- 🎉 初始版本
-- ✅ 基础故事生成功能
-
-**完整更新日志**：查看 [Git Commits](https://github.com/your-username/ghost-story-factory/commits/main)
-
----
-
-## 📞 联系方式
-
-- **Issues**: [GitHub Issues](https://github.com/your-username/ghost-story-factory/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/your-username/ghost-story-factory/discussions)
-- **Email**: your@email.com
-
----
-
-## ⭐ Star History
-
-如果这个项目对您有帮助，请给一个 Star ⭐！
-
----
-
-<p align="center">
-  <strong>用 AI 讲好中国的都市传说故事 🎭👻</strong>
-</p>
-
-<p align="center">
-  Made with ❤️ by <a href="https://github.com/your-username">Your Name</a>
-</p>
+MIT

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -1,0 +1,356 @@
+# SCRIPTING — 给想自己写剧本的人
+
+本文档面向**想写一个新故事 / 改这个故事 / 加角色**的人。不读源码,
+读完这一份你就能写出 audit_all 全绿的剧本。
+
+---
+
+## 1. 工作流概览
+
+```
+你编辑 → _fragment_v7_*.json     ← 手写
+       ↓
+tools/merge_fragments.py         ← 合并 9 个 fragment
+       ↓
+stories/<story>/tree.json        ← 引擎读这一份
+       ↓
+python play_tui.py              ← 玩
+```
+
+每改完 fragment,**必须做这两步**:
+```bash
+python tools/merge_fragments.py    # 编译 tree.json
+bash tools/audit_all.sh             # 跑 13 项审计,全绿才算改完
+```
+
+---
+
+## 2. 数据形态(Linus 风格:先讲数据,再讲代码)
+
+整个剧本就是一棵 `tree.json`,结构:
+
+```jsonc
+{
+  "story_id": "杭州_v7",
+  "start_node": "n_intro",
+
+  "characters": { "G-273": {...}, "linmou_1985": {...} },
+  "endings": { "E_TRUE": "...展示名", "E_TRUTH": "...", ... },
+
+  "reaction_contracts": {
+    "deductions":   { "predecessor_loop": {...} },
+    "foreshadows":  { "lakeside_drown":   {...} },
+    "themes":       { "hangzhou_constant":{...} }
+  },
+
+  "nodes": {
+    "n_intro": { "narrative": "...", "choices": [...] },
+    "n_landmark_picker": { "_is_map_picker": true, ... },
+    ...
+  }
+}
+```
+
+**节点 = 一段叙事 + 一组选择**。玩家进入一个节点,看到叙事文本,
+从 `choices` 里选一项,引擎根据 `effects` 修改状态,跳到 `next` 指向的下一个节点。
+
+---
+
+## 3. 沙盒拓扑 — 这是第一公理(ADR-010)
+
+**坏剧本** = 线性单链 entry → A → B → C → ending。
+**好剧本** = 沙盒:玩家可以在一个 hub 横向探索,反复访问,做累积。
+
+写新角色的最小沙盒骨架(少一条都不行):
+
+| 必备元素 | 含义 | 例子 |
+|---|---|---|
+| 1 个 `_is_map_picker: true` hub | 玩家从这里挑去哪 | `n_landmark_picker` |
+| ≥ 4 个地标,每个 ≥ 1 条 `connections` 邻边 | 地标之间能横向跳,不是辐射 | `n_l1985_abacus_01` 邻 `n_l1985_boiler_01` |
+| ≥ 2 个 `_is_tool: true` 节点 | 可反复使用的工具(对讲机 / 论坛 / ...) | `n_npc_predecessor_voice` |
+| ≥ 1 处 `effects.stay: true` | 工具用完留在原地,不强制跳走 | 翻论坛后还在论坛页 |
+| ≥ 1 处反应 clause variants | 看过某线索后,这个节点文案自动变 | 见 § 5 |
+
+参考实现:G-273 周目(`n_landmark_picker` 56 入边 + 7 地标 + 9 工具)。
+
+**绝对禁止**:
+- ❌ 加 `flags` 镜像伏笔/推论解开(违反 ADR-007/008 单一真相源)
+- ❌ 加 state 字段表达"玩家见过 X"——查 `endings_seen` / `foreshadows_seen` / `deductions_resolved` 就够
+- ❌ 工具节点 `next` 直接跳走(应该 `effects.stay: true`)
+- ❌ NPC 反复访问 narrative 不变(应该 `narrative_variants` 切档)
+
+`audit_sandbox.py` 一键检 ADR-010 合规。
+
+---
+
+## 4. 节点写法
+
+### 4.1 普通对话节点
+
+```jsonc
+{
+  "n_scene_lakeside": {
+    "narrative": "湖边没有人。风从对岸吹过来,带着潮味。",
+    "choices": [
+      {
+        "label": "走近湖边",
+        "next": "n_scene_lakeside_close",
+        "effects": { "GR": 1, "landmark_visited": "S2" }
+      },
+      {
+        "label": "原路返回",
+        "next": "n_landmark_picker",
+        "require": { "inv_lacks": ["对讲机"] }
+      }
+    ]
+  }
+}
+```
+
+**关键字段**:
+- `narrative` — 默认文案(如果有 `narrative_variants` 且某条命中,优先用那条)
+- `choices[].label` — 玩家看到的选项文字
+- `choices[].next` — 跳到哪个节点
+- `choices[].effects` — 选这条会改什么状态(见 § 4.3)
+- `choices[].require` — 满足条件才显示这个选项(见 § 4.4)
+
+### 4.2 picker hub(地图中枢)
+
+```jsonc
+{
+  "n_landmark_picker": {
+    "_is_map_picker": true,
+    "narrative": "你又站在地图前。",
+    "landmark_map": {
+      "S1": "n_s1_arrive",
+      "S2": "n_s2_arrive",
+      ...
+    },
+    "connections": {
+      "S1": ["S2", "S6"],
+      "S2": ["S1", "S3"],
+      ...
+    }
+  }
+}
+```
+
+`landmark_map` 是 picker 到地标的映射;`connections` 是地标之间的邻接图,
+让玩家能从 S1 直接跳 S2 而不必回 picker。
+
+### 4.3 effects(选择后果)
+
+```jsonc
+{
+  "effects": {
+    "PR": 5,                          // 玩家分数 +5(取证/秩序倾向)
+    "GR": -3,                          // 鬼分数 -3(被同情倾向)
+    "inv_add": ["⺶ 符文"],            // 加道具
+    "inv_remove": ["工牌 G-273"],      // 减道具
+    "flags": { "arc.named_the_dead": true },  // 设标志
+    "landmark_visited": "S3",          // 标记地标已访
+    "shifts_completed": 1,             // 班次完成 +1
+    "shifts_skipped": 0,
+    "puzzle_add": "P3",                // 拼图碎片 +1
+    "npc_move": { "predecessor": "n_lore_predecessor_office" },
+    "stay": true                       // 工具节点:执行完留在原地
+  }
+}
+```
+
+**flags 命名规范**(ADR-007):
+- `arc.*` — 长期人格弧线(`arc.named_the_dead` / `arc.became_judge`)
+- `know.*` — 已知信息(`know.saw_8_zhao`)
+- `oneshot.*` — 一次性事件(`oneshot.posted_photo`)
+- `route.*` — 路径走过(`route.behavior_self_audit`)
+
+### 4.4 require(满足才显示 / 才跳转)
+
+```jsonc
+{
+  "require": {
+    "PR_min": 30,                                // PR ≥ 30
+    "inv_has": ["对讲机", "工牌 G-273"],          // 同时有这俩
+    "inv_lacks": ["羊血"],                        // 没有羊血
+    "flags": { "arc.named_the_dead": true },      // 此 flag 已 true
+    "puzzle_pieces_min": 3,                       // 至少 3 个拼图碎片
+    "shifts_completed_min": 2,                    // 已完成 2 个班
+    "landmark_visited": ["S3"],                   // 访过 S3
+    "visit_count_min": { "n_npc_drowned": 2 },    // 访过 n_npc_drowned 至少 2 次
+    "deduction_resolved": "predecessor_loop",     // 解开了某推论(见 § 6)
+    "foreshadow_resolved": "lakeside_drown",      // 解开了某伏笔
+    "theme_resolved": "hangzhou_constant",        // 解开了某母题
+    "ending_seen": { "story_id": "杭州_v7", "ending_id": "E_TRUE" },  // 跨周目(见 § 7)
+
+    // 组合逻辑:
+    "any_of": [ {...}, {...} ],   // 任一满足
+    "all_of": [ {...}, {...} ],   // 都要满足
+    "not":    { ... }              // 反向
+  }
+}
+```
+
+---
+
+## 5. 反应式 variants — NPC / 场景的"看过会变"
+
+```jsonc
+{
+  "n_npc_predecessor_voice": {
+    "narrative": "对讲机滋滋响,前任的声音从远处传来。",
+    "narrative_variants": [
+      {
+        "if": { "ending_seen": { "story_id": "杭州_v7", "last": "E_DATA" } },
+        "text": "对讲机接通。背景**只有键盘敲击的连音**——前任先报字段名问你 schema..."
+      },
+      {
+        "if": { "deduction_resolved": "predecessor_loop" },
+        "text": "你按下对讲机。这次另一头先沉默了一拍——很长的一拍..."
+      }
+    ]
+  }
+}
+```
+
+**first-match 顺序**:引擎从 `narrative_variants[0]` 开始遍历,
+第一个 `if` 满足的就用它的 `text`,都不满足才 fallback 到 `narrative`。
+**所以最具体 / 最稀有的条件放前面**。
+
+`audit_variants.py` 检"反复访问 narrative 不变"的节点(那是死剧本红线)。
+
+---
+
+## 6. reaction_contracts — 伏笔 / 推论 / 母题
+
+```jsonc
+"reaction_contracts": {
+  "deductions": {
+    "predecessor_loop": {
+      "_label": "前任在 1985 年没下班",
+      "consumer_nodes": ["n_npc_predecessor_voice", "n_intro"],
+      "trigger_type": "per_run"
+    }
+  },
+  "foreshadows": {
+    "lakeside_drown": {
+      "_label": "湖边的影子",
+      "consumer_nodes": ["n_scene_lakeside"],
+      "trigger_type": "per_run"
+    }
+  },
+  "themes": {
+    "hangzhou_constant": {
+      "_label": "杭州常数",
+      "manifestations": ["lakeside_drown", "predecessor_loop"],
+      "consumer_nodes": ["n_intro", "n_landmark_picker"]
+    }
+  }
+}
+```
+
+`_label` 是人类可读名(audit_foreshadow_chain 要求必填);
+`consumer_nodes` 声明"我打算被这些节点 require 消费";
+`trigger_type` 决定生效范围(`per_run` 本周目 / `cross_run` 跨周目)。
+
+写一条 deduction/foreshadow/theme 进来,**必须**有节点的 require 真的引用它,
+否则 `audit_foreshadow_chain.py` 会报 `CONSUMER_NOT_CONSUMING`。
+
+---
+
+## 7. 跨周目联动(0 新存档字段)
+
+存档里有一个不可妥协的真相源:
+```json
+{
+  "endings_seen": {
+    "杭州_v7": ["E_TRUTH", "E_DATA", "E_TRUE"]
+  }
+}
+```
+
+按通关顺序追加,**重复通关时移到末尾**——所以 `list[-1]` 永远是最近一次。
+
+剧本端用两种形式消费:
+
+| 形式 | 语义 | 用途 |
+|---|---|---|
+| `ending_seen.ending_id: "E_X"` | "曾经通关过 E_X"(历史里出现) | 物质遗迹("纸袋还在")、广义反咬 |
+| `ending_seen.last: "E_X"` | "**最近一次**通关是 E_X" | 人格惯性、开场残影 |
+| `ending_seen.ending_id: "*"` | "本 story 通关过任意 ending" | 二周目入口 |
+
+`audit_profile_inheritance.py` 强制 5 个 main ending(E_TRUE/TRUTH/BROADCAST/DATA/HIDDEN)
+都必须有 ≥ 1 个非结局节点用 `.last` 反咬。BAD/NEUTRAL/LINMOU ending 不在此约束范围。
+
+ADR-011 列了 5 条 main ending 的人格画像参考映射。
+
+---
+
+## 8. 结局节点
+
+```jsonc
+{
+  "n_end_true": {
+    "is_ending": true,
+    "ending_type": "E_TRUE",
+    "narrative": "天快亮了。你回到 G-273 工位,把工牌放下..."
+  }
+}
+```
+
+`is_ending: true` + `ending_type` 唯一标识。tree 顶层的 `endings` 字段给展示名。
+
+**linmou 前传线**(1985 年的林某)有"必死不变量"——所有 `E_LINMOU_*` ending 节点
+都必须有 `_lore_canon.must_die: true`,见 ADR-009。`audit_paths_linmou.py` 守门。
+
+---
+
+## 9. 13 项审计速查
+
+`bash tools/audit_all.sh` 一键跑:
+
+| # | 工具 | 守什么 |
+|---|---|---|
+| 1 | `audit_playability` | GameTree 可玩闭环(每个节点都能走到 ending) |
+| 2 | `audit_sandbox` | ADR-010 沙盒五项骨架 |
+| 3 | `audit_script_depth` | Pass 9 厚度(节点数 / 演出意图 / 林某线深度) |
+| 4 | `audit_tree` | 节点引用完整性 + lore 红线 |
+| 5 | `audit_state` | flags / inv 引用矩阵(写没人读的 flag 会报) |
+| 6 | `audit_variants` | 反复访问 narrative 不变的节点 |
+| 7 | `audit_reactions` | ADR-008 反应契约三红线 |
+| 8 | `audit_paths_linmou` | linmou 必死不变量 |
+| 9 | `audit_foreshadow_chain` | 伏笔链条完整性(_label / consumer_nodes 真消费) |
+| 10 | `audit_cross_run_continuity` | 跨周目消费侧覆盖 |
+| 11 | `audit_variant_trigger` | variant 触发难度(防"写了没人见到") |
+| 12 | `audit_protagonist_behavior` | G-273 每个 ending 必须识别玩家(behavior_profile / *_resolved / flags / inv_has) |
+| 13 | `audit_profile_inheritance` | 5 main ending 必须有 `.last` 反咬 |
+
+---
+
+## 10. ADR 索引(契约本体)
+
+| ADR | 内容 |
+|---|---|
+| ADR-007 | 状态空间契约 + Flag 命名规范 |
+| ADR-008 | 反应机制 + 跨周目认知继承 |
+| ADR-009 | linmou_1985 周目契约(必死不变量) |
+| ADR-010 | **沙盒拓扑(第一公理)— 这是沙盒不是死剧本** |
+| ADR-011 | 人格惯性 `ending_seen.last` 协议 |
+
+详见 `docs/architecture/`。
+
+---
+
+## 11. 工作清单(写新角色 / 新场景前打钩)
+
+- [ ] 角色注册在 `tree.start_node` 或 `characters.<id>.start_node`
+- [ ] picker hub 节点存在,`_is_map_picker: true`
+- [ ] ≥ 4 个地标,`connections` 邻接图至少覆盖一遍
+- [ ] ≥ 2 个 `_is_tool: true` 工具节点
+- [ ] ≥ 1 处 `effects.stay: true`
+- [ ] ≥ 1 处 `narrative_variants` 反应切档
+- [ ] 不引入新 flag 镜像伏笔/推论(查 `audit_state.py`)
+- [ ] 主结局都有 `behavior_profile` / `*_resolved` / `flags` / `inv_has` 识别玩家
+- [ ] 跨周目主结局有 `.last` 反咬(`audit_profile_inheritance`)
+- [ ] `merge_fragments.py` 跑通,`audit_all.sh` 13/13 全绿
+
+每一条都对应一个 audit 工具——audit 全绿 = 剧本进引擎不会崩、能玩出层次。


### PR DESCRIPTION
## Summary

按 PIVOT 文档执行 Step 2。**纯文档 PR,零代码改动**。

### README.md(-678 / +78,从 739 行 → 139 行)

旧 README 围绕 v0.1.0 LLM 流水线和 Top-Down 叙事设计写,
对一个想玩游戏的朋友完全无用。重写主轴:

- **顶部**:剧情卖点(夜班保安 G-273 / 8 张照片 / 一晚)
- **数据**:162 节点 / 12 种结局
- **玩法 A**:源码运行(uv venv + pip install -e .)
- **玩法 B**:pipx 安装(已知装包路径限制)
- **控制速查**:菜单 / 游戏两套快捷键
- **剧情结构表**:5+3+4 ending 三类
- **跨周目人格惯性举例**:E_TRUE 衣袋找信 / E_DATA 对讲机字段名
- **项目结构**:对齐 Step1 瘦身后的真实 4 模块
- **历史代码**:明确指向 legacy/llm-pipeline 分支

### docs/SCRIPTING.md(新增,356 行)

面向"想自己写剧本的人",涵盖:

- 工作流(手写 fragment → merge → audit → play)
- 数据形态(Linus 风格:先讲数据再讲代码)
- ADR-010 沙盒第一公理 + 最小骨架清单
- 节点写法详解(普通 / picker hub / effects / require)
- 反应式 variants(first-match 顺序与陷阱)
- reaction_contracts(deduction / foreshadow / theme 三类)
- 跨周目 `ending_seen.ending_id` vs `.last` 区别
- linmou 必死不变量(ADR-009)
- **13 项 audit_all 速查表**
- ADR-007~011 索引
- **写新角色/场景前的 11 项 checklist**

每条 checklist 都对应一个 audit 工具,完成后 audit_all 13/13 自然全绿。

## Test plan

- [x] 视觉确认 README 和 SCRIPTING 渲染正确
- [x] 所有外链路径有效(legacy 分支、ADR、docs/INDEX.md)
- [x] checklist 内容与现实 audit 工具一一对应

## 不在本 PR 范围

- docs/COMMANDS.md / PREGENERATION_DESIGN.md 等历史文档清理(留给后续)
- ENV_EXAMPLE.md(LLM 时代产物)清理
- Step 3:PyInstaller release